### PR TITLE
重構：更新鍵綁定並刪除不必要的大括號

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -264,20 +264,20 @@
    AS(GRAVE) &trans    &trans    AS(COMMA) &kp COLON     &kp SEMI  AS(DOT)   &kp LCTRL &kp RALT &trans
                        &kp LGUI  &kp ESC   &kp SPACE     AS(RET)   &trans    &kp TAB
                         >;
-                };
+
 
                 func_layer {
 // -----------------------------------------------------------------------------------------
-// | 1! |  2@ |  3# |  4$ |  5% |     |  6^ |  7& |  8* |  9(  |  0)  |
-// | -_ |  =+ |  {  |  [  |  (  |     |  )  |  ]  |  }  |  /?  |  \|  |
-// | `~ |     |     |  ,< |  :  |     |  ;  |  .> | CTRL| META |      |
+// | F1 |  F2 |  F3 |  F4 |  F5 |     |  F6 |  F7 |  F8 |  F9  |  F10 |
+// |    |     |     |     | F11 |     | F12 |     |     |      |      |
+// |    |     |     |     |     |     |     |     | CTRL| META |      |
 //            | GUI | ESC | SPC |     | ENT |     | TAB |
                         display-name = "Func";
                         bindings = <
 
-   &kp F1 &kp F2 &kp F3   &kp F4  &kp F5      &kp F6   &kp F7 &kp F8    &kp F9 &kp F10
-   &trans &trans &trans   &trans  &kp F11     &kp F12  &trans &trans    &trans &trans
-   &trans &trans &trans   &trans  &trans      &kp SEMI &trans &kp LCTRL &trans &trans
+   &kp F1 &kp F2 &kp F3   &kp F4  &kp F5      &kp F6   &kp F7 &kp F8    &kp F9   &kp F10
+   &trans &trans &trans   &trans  &kp F11     &kp F12  &trans &trans    &trans   &trans
+   &trans &trans &trans   &trans  &trans      &kp SEMI &trans &kp LCTRL &kp RALT &trans
                  &kp LGUI &kp ESC &kp SPACE   AS(RET)  &trans &kp TAB
                         >;
                 };


### PR DESCRIPTION
- 移除不必要的大括號
- 更新`“config/corne.keymap”`中功能鍵F1到F10的鍵綁定
- 為功能鍵F10新增Alt鍵綁定

Signed-off-by: HomePC-WSL <jackie@dast.tw>
