### PR TITLE
修正：重新組織 Windows 鍵的鍵映射和識別符

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -244,10 +244,10 @@
         WIN_DEF_layer {
             display-name = "Windows";
             bindings = <
-  &kp Q  &kp W  &kp E  &kp R            &kp T                   &kp Y          &kp U                  &kp I      &kp O       &kp P
-  &kp A  &kp S  &kp D  &kp F            &kp G                   &kp H          &kp J                  &kp K      &kp L       &kp SEMICOLON
-  &kp Z  &kp X  &kp C  &kp V            &kp B                   &kp N          &kp M                  &kp COMMA  &kp PERIOD  &kp SLASH
-                &gaw   &lt WinCode ESC  &ht LEFT_SHIFT SPACE    &ht LCTRL RET  &lt WIN_NUM BACKSPACE  &kp TAB
+  &kp Q  &kp W  &kp E  &kp R             &kp T                   &kp Y          &kp U                  &kp I      &kp O       &kp P
+  &kp A  &kp S  &kp D  &kp F             &kp G                   &kp H          &kp J                  &kp K      &kp L       &kp SEMICOLON
+  &kp Z  &kp X  &kp C  &kp V             &kp B                   &kp N          &kp M                  &kp COMMA  &kp PERIOD  &kp SLASH
+                &gaw   &lt WIN_CODE ESC  &ht LEFT_SHIFT SPACE    &ht LCTRL RET  &lt WIN_NUM BACKSPACE  &kp TAB
             >;
         };
 


### PR DESCRIPTION
- 更新 `WIN_CODE` 和 `WIN_NUM` 的鍵映射
- 修正 `WinCode` 鍵識別符中的拼字錯誤

Signed-off-by: HomePC <jackie@dast.tw>
