### PR TITLE
特性: 根據需要，更新調整修飾鍵和 `LGUI` 的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -103,9 +103,9 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
-                <&macro_press &kp LGUI>,
+                <&macro_press &kp LCMD>,
                 <&macro_tap &kp SPACE>,
-                <&macro_release &kp LGUI>;
+                <&macro_release &kp LCMD>;
 
             label = "SPOTLIGHT";
         };
@@ -114,9 +114,9 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
-                <&macro_press &kp LG(LSHIFT)>,
+                <&macro_press &kp LG(LSHFT)>,
                 <&macro_tap &kp N4>,
-                <&macro_release &kp LG(LSHIFT)>;
+                <&macro_release &kp LG(LSHFT)>;
 
             label = "SCREENSHOT";
         };
@@ -171,10 +171,10 @@
         MAC_DEF_layer {
             display-name = "macOS";
             bindings = <
-  &kp Q  &kp W  &kp E     &kp R             &kp T               &kp Y            &kp U             &kp I      &kp O       &kp P
-  &kp A  &kp S  &kp D     &kp F             &kp G               &kp H            &kp J             &kp K      &kp L       &kp SEMICOLON
-  &kp Z  &kp X  &kp C     &kp V             &kp B               &kp N            &kp M             &kp COMMA  &kp PERIOD  &kp SLASH
-                &kp LGUI  &lt MAC_CODE ESC  &ht LSHIFT SPACE    &ht LCTRL ENTER  &lt MAC_NAV BSPC  &kp TAB
+  &kp Q  &kp W  &kp E     &kp R             &kp T              &kp Y            &kp U             &kp I      &kp O       &kp P
+  &kp A  &kp S  &kp D     &kp F             &kp G              &kp H            &kp J             &kp K      &kp L       &kp SEMICOLON
+  &kp Z  &kp X  &kp C     &kp V             &kp B              &kp N            &kp M             &kp COMMA  &kp PERIOD  &kp SLASH
+                &kp LCMD  &lt MAC_CODE ESC  &ht LSHFT SPACE    &ht LCTRL ENTER  &lt MAC_NAV BSPC  &kp TAB
             >;
 
             label = "MAC_DEF";
@@ -186,7 +186,7 @@
   &kp EXCLAMATION  &kp AT     &kp HASH        &kp DOLLAR    &kp PERCENT      &kp NON_US_BACKSLASH  &kp N7  &kp N8          &kp N9  &kp COMMA
   &kp PLUS         &kp EQUAL  &kp UNDERSCORE  &kp MINUS     &kp CARET        &kp N0                &kp N4  &kp N5          &kp N6  &kp PERIOD
   &t_row           &t_col     &kp TAB         &kp ASTERISK  &kp AMPERSAND    &kp SEMICOLON         &kp N1  &kp N2          &kp N3  &kp SLASH
-                              &trans          &trans        &trans           &trans                &trans  &kp LC(LSHIFT)
+                              &trans          &trans        &trans           &trans                &trans  &kp LC(LSHFT)
             >;
 
             label = "MAC_CODE";
@@ -196,7 +196,7 @@
             display-name = "Nav";
             bindings = <
   &spot      &kp LG(ENTER)  &shot     &spot           &kp C_VOLUME_UP     &kp HOME  &kp PG_DN  &kp PG_UP   &kp END     &none
-  &kp LCTRL  &kp LGUI       &kp LALT  &ht LSHIFT TAB  &kp C_VOL_DN        &kp LEFT  &kp DOWN   &kp UP      &kp RIGHT   &none
+  &kp LCTRL  &kp LCMD       &kp LALT  &ht LSHFT TAB   &kp C_VOL_DN        &kp LEFT  &kp DOWN   &kp UP      &kp RIGHT   &none
   &t_crt     &t_list        &none     &kp C_AC_PASTE  &kp C_PLAY_PAUSE    &kp INS   &kp DEL    &kp C_PREV  &kp C_NEXT  &none
                             &trans    &trans          &trans              &trans    &trans     &trans
             >;
@@ -208,7 +208,7 @@
             display-name = "Func";
             bindings = <
   &kp F1  &kp F2  &kp F3  &kp F4   &kp F5     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-  &kp F6  &kp F7  &kp F8  &kp F9   &kp F10    &none         &none         &none         &none         &bt BT_CLR
+  &kp F6  &kp F7  &kp F8  &kp F9   &kp F10    &none         &none         &none         &bootloader   &bt BT_CLR
   &none   &none   &none   &kp F11  &kp F12    &none         &none         &none         &none         &none
                   &trans  &trans   &trans     &trans        &trans        &trans
             >;


### PR DESCRIPTION
- 將 `LGUI` 鍵的按鍵綁定更改為使用 `LCMD`
- 將 `LG(LSHIFT)` 的按鍵綁定更正為 `LG(LSHFT)`
- 調整涉及修飾鍵的按鍵綁定以確保相容性

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
