### PR TITLE
修復：更新 corne.keymap 設置中的按鍵綁定，以改善導航

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -196,7 +196,7 @@
         NAV_layer {
             display-name = "Nav";
             bindings = <
-  &spot      &kp LG(ENTER)  &shot     &spot          &kp C_VOL_UP    &kp HOME  &kp PG_DN  &kp PG_UP   &kp END     &none
+  &max       &kp LG(ENTER)  &shot     &spot          &kp C_VOL_UP    &kp HOME  &kp PG_DN  &kp PG_UP   &kp END     &none
   &kp LCTRL  &kp LCMD       &kp LALT  &ht LSHFT TAB  &kp C_VOL_DN    &kp LEFT  &kp DOWN   &kp UP      &kp RIGHT   &none
   &t_crt     &t_list        &none     &none          &kp C_PP        &kp INS   &kp DEL    &kp C_PREV  &kp C_NEXT  &none 
                             &trans    &trans         &trans          &trans    &trans     &trans


### PR DESCRIPTION
- 在 corne.keymap 設置中的導航層中更新 `max` 的綁定

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
