### PR TITLE
修正：重構按鍵處理和修飾鍵使用

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -38,7 +38,7 @@
             bindings = <&kp Q>, <&kp LA(TAB)>;
 
             #binding-cells = <0>;
-            mods = <(MOD_LGUI)>;
+            mods = <(MOD_LSHFT)>;
         };
     };
 
@@ -114,7 +114,9 @@
             bindings = <&macro_press &kp LWIN>,
                        <&macro_tap &kp R>,
                        <&macro_release &kp LWIN>,
-                       <&macro_tap &kp W &kp T &kp RET>;
+                       <&macro_tap>,
+                       <&macro_wait_time 350>,
+                       <&kp W &kp T &kp RET>;
 
             label = "TERMINAL";
         };


### PR DESCRIPTION
- 將修飾鍵從 `MOD_LGUI` 變更為 `MOD_LSHFT`
- 修改按鍵序列並為終端命令執行添加延遲

Signed-off-by: Macbook <jackie@dast.tw>
