### PR TITLE
修正：更新 corne.keymap 中 tmux 指令的綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -87,7 +87,7 @@
         t_row: tmux_row {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap &kp LC(A) &kp MINUS>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp MINUS>;
 
             label = "TMUX_ROW";
         };
@@ -95,7 +95,7 @@
         t_list: tmux_list {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap &kp LC(A) &kp W>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp W>;
 
             label = "TMUX_LIST";
         };
@@ -103,7 +103,7 @@
         t_crt: tmux_create {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap &kp LC(A) &kp C>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp C>;
 
             label = "TMUX_CREATE";
         };


### PR DESCRIPTION
- 更新 `corne.keymap` 中 tmux_row、tmux_list 和 tmux_create 的綁定

Signed-off-by: Macbook <jackie@dast.tw>
