### PR TITLE
修復：更新按鍵綁定和配置

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -90,11 +90,11 @@
             #binding-cells = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LG(LC(LSHFT)>,
+                <&kp LG(LC(LSHFT))>,
                 <&macro_tap>,
                 <&kp N4>,
                 <&macro_release>,
-                <&kp LG(LC(LSHFT)>;
+                <&kp LG(LC(LSHFT))>;
 
             label = "SCREENSHOT";
         };


### PR DESCRIPTION
- 在 `corne.keymap` 中更新按鍵綁定
- 修正按鍵綁定配置中的拼寫錯誤

Signed-off-by: Macbook <jackie@dast.tw>
