### PR TITLE
特性: 重新配置 ALT_WIN 和 TERMINAL 命令的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -43,7 +43,7 @@
             compatible = "zmk,behavior-tap-dance";
             label = "ALT_WIN";
             #binding-cells = <0>;
-            bindings = <&kp LWIN>, <&kp LALT>;
+            bindings = <&kp LALT>, <&kp LWIN>;
         };
 
         win_ter_col: win_ter_col {
@@ -205,7 +205,7 @@
                 <&macro_release>,
                 <&kp LWIN>,
                 <&macro_tap>,
-                <&kp W &kp T &kp RET>;
+                <&kp BSPC &kp W &kp T &kp RET>;
 
             label = "TERMINAL";
         };


### PR DESCRIPTION
- 重新排序 `bindings` 以便 `ALT_WIN` 鍵盤映射
- 更新 `TERMINAL` 標籤的按鍵綁定

Signed-off-by: OfficePC <jackie@dast.tw>
