### PR TITLE
功能: 重構巨集鍵組合和等待時間

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -205,7 +205,8 @@
                 <&macro_release>,
                 <&kp LWIN>,
                 <&macro_tap>,
-                <&kp BSPC &kp W &kp T &kp RET>;
+                <&kp W &kp T &kp RET>,
+                <&macro_wait_time 350>;
 
             label = "TERMINAL";
         };


### PR DESCRIPTION
- 從巨集中刪除組合 `&lt;&amp;kp BSPC &amp;kp W &amp;kp T &amp;kp RET&gt;`
- 將組合 `&lt;&amp;kp W &amp;kp T &amp;kp RET&gt;` 和 `&lt;&amp;macro_wait_time 350&gt;` 添加到巨集

Signed-off-by: OfficePC <jackie@dast.tw>
