### PR TITLE
重構:為了一致性修改巨集和按鍵綁定名稱

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -85,7 +85,7 @@
     };
 
     macros {
-        ter_win : windows_terminal {
+        win_ter: windows_terminal {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
@@ -296,7 +296,7 @@
             bindings = <
   &kp N1     &kp N2   &kp N3    &kp N4    &kp N5       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0
   &shot_win  &kp TAB  &max_win  &kp HOME  &kp PG_UP    &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &th LC(LSHFT) LC(TAB)
-  &ter_win   &none    &min_win  &kp END   &kp PG_DN    &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LA(F9)
+  &win_ter   &none    &min_win  &kp END   &kp PG_DN    &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LA(F9)
                       &trans    &trans    &trans       &trans        &trans        &trans
             >;
 


### PR DESCRIPTION
- 將巨集名稱`ter_win`更改為`win_ter`
- 更新按鍵綁定`&amp;ter_win`為`&amp;win_ter`

Signed-off-by: HomePC <jackie@dast.tw>
