### PR TITLE
功能：重構鍵綁定並優化配置

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -76,6 +76,7 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
+                <&macro_tap &kp ESC>,
                 <&macro_press &kp LWIN>,
                 <&macro_tap &kp R>,
                 <&macro_release &kp LWIN>,


### PR DESCRIPTION
- 在 `config/corne.keymap` 中添加一個巨集綁定來配置 `ESC` 鍵

Signed-off-by: OfficePC <jackie@dast.tw>
