### PR TITLE
功能: 重構鍵綁定和宏組合

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -76,14 +76,11 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
-                <&macro_tap &kp ESC>,
                 <&macro_press &kp LWIN>,
                 <&macro_tap &kp R>,
                 <&macro_release &kp LWIN>,
                 <&macro_pause_for_release>,
-                <&macro_tap &kp W &kp T>,
-                <&macro_pause_for_release>,
-                <&macro_tap &kp RET>;
+                <&macro_tap &kp W &kp T &kp RET>;
         };
 
         w_col: win_column {


### PR DESCRIPTION
- 從 `corne.keymap` 中刪除兩個鍵綁定並更新一個鍵綁定
- 調整 `W T RET` 序列的宏組合

Signed-off-by: OfficePC <jackie@dast.tw>
