### PR TITLE
chore: update keymap configuration and improve readability

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -92,7 +92,6 @@
                 <&macro_release>,
                 <&kp LCTRL &kp LSHFT>,
                 <&macro_pause_for_release>,
-                <&macro_tap &kp W &kp S &kp L>,
                 <&macro_tap &kp RET>;
         };
 


### PR DESCRIPTION
- Remove the line that taps `W S L` from the keymap configuration

Signed-off-by: HomePC <jackie@dast.tw>
