### PR TITLE
refactor: refactor keypress sequences in code input

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -82,7 +82,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp E &kp Z &kp T &kp E &kp R &kp M &kp MINUS &kp G &kp U &kp I &kp RET>;
+                <&kp W &kp E &kp RET>;
         };
 
         ter_mac: terminal_macos {


### PR DESCRIPTION
- Remove the sequence of keyspresses involving `W E Z T E R M MINUS G U I RET`;
- Add a keypress sequence involving `W E RET`.

Signed-off-by: OfficePC <jackie@dast.tw>
