### PR TITLE
重構：在PR中重新設計跨檔案的按鍵組合

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -89,7 +89,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp E &kp Z &kp T &kp E &kp R &kp M &kp RET>;
+                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
         };
 
         shot_win: screenshot_win {


### PR DESCRIPTION
- 從 `W E Z T E R M RET` 更改為 `G H O S T T Y RET`

Signed-off-by: HomePC-WSL <jackie@dast.tw>
