### PR TITLE
特性: 優化按鍵綁定和行為配置

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -15,5 +15,6 @@
 include:
   - board: nice_nano_v2
     shield: corne_left nice_view_adapter nice_view
+    snippet: studio-rpc-usb-uart
   - board: nice_nano_v2
     shield: corne_right nice_view_adapter nice_view

--- a/config/corne.conf
+++ b/config/corne.conf
@@ -6,7 +6,11 @@ CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
 
 # Enable eager debouncing
 CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS=1
-CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=7
+CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=10
+
+# Enable ZMK Studio for Realtime Keymap Updates
+CONFIG_ZMK_STUDIO=y
+CONFIG_ZMK_STUDIO_LOCKING=n
 
 # Uncomment the following line to enable USB Logging (this increases power usage by a significant amount, turn it off when not in use)
 # CONFIG_ZMK_USB_LOGGING=y

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -29,15 +29,6 @@
             bindings = <&kp>, <&kp>;
         };
 
-        bm: bspc_mod {
-            compatible = "zmk,behavior-hold-tap";
-            flavor = "balanced";
-            #binding-cells = <2>;
-            tapping-term-ms = <200>;
-            quick-tap-ms = <150>;
-            bindings = <&mo>, <&kp>;
-        };
-
         td_win: td_win {
             compatible = "zmk,behavior-tap-dance";
             #binding-cells = <0>;
@@ -215,7 +206,7 @@
   &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U             &kp I      &kp O    &kp P
   &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J             &kp K      &kp L    &kp SEMI
   &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M             &kp COMMA  &kp DOT  &kp FSLH
-                &td_win  &lt CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &bm WIN_NAV BSPC  &kp TAB
+                &td_win  &lt CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lt WIN_NAV BSPC  &kp TAB
             >;
         };
 
@@ -237,7 +228,7 @@
   &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U             &kp I      &kp O    &kp P
   &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J             &kp K      &kp L    &kp SEMI
   &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M             &kp COMMA  &kp DOT  &kp FSLH
-                &td_mac  &lt CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &bm MAC_NAV BSPC  &kp TAB
+                &td_mac  &lt CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lt MAC_NAV BSPC  &kp TAB
             >;
         };
 


### PR DESCRIPTION
- 在`build.yaml`中新增了一個名為`studio-rpc-usb-uart`的新片段
- 將`corne.conf`中的按鍵抖動釋放時間從`7`更改為`10`
- 在`corne.conf`中啟用 ZMK Studio 以進行實時鍵盤映射更新
- 從`corne.keymap`中刪除了`bm: bspc_mod`行為
- 更新了`corne.keymap`中的按鍵綁定，以符合`td_win`和`td_mac`行為

Signed-off-by: HomePC-WSL <jackie@dast.tw>
