### PR TITLE
功能：優化電源管理設定和無線範圍

### DIFF
--- a/config/corne.conf
+++ b/config/corne.conf
@@ -1,5 +1,5 @@
 # Uncomment the following line to enable deep sleep
-CONFIG_ZMK_SLEEP=y
+# CONFIG_ZMK_SLEEP=y
 
 # Uncomment the following line to increase the keyboard's wireless range
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y


### PR DESCRIPTION
- 註釋掉`corne.conf`中的`CONFIG_ZMK_SLEEP`以禁用深度睡眠模式
- 啟用`CONFIG_BT_CTLR_TX_PWR_PLUS_8`以增加鍵盤的無線範圍

Signed-off-by: HomePC-WSL <jackie@dast.tw>
