### PR TITLE
重構：為各種組合重新設計按鍵映射

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -59,7 +59,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp E &kp Z &kp RET>;
+                <&kp W &kp E &kp Z &kp T &kp E &kp R &kp M &kp MINUS &kp G &kp U &kp I &kp RET>;
         };
 
         ter_mac: terminal_macos {


### PR DESCRIPTION
- 更新組合 'WEZTERM-GUI' 的按鍵映射設定
- 修改 `corne.keymap` 的按鍵映射，新增額外的按鍵組合。

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
