### PR TITLE
修正：重構按鍵綁定以提升兼容性和導航

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -31,7 +31,7 @@
             require-prior-idle-ms = <125>;
         };
 
-        em: esc_mod {
+        lm: layer_mod {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
@@ -216,10 +216,10 @@
             label = "WIN_DEF";
             display-name = "Windows";
             bindings = <
-  &kp Q  &kp W  &kp E    &kp R      &kp T              &kp Y          &kp U       &kp I      &kp O    &kp P
-  &kp A  &kp S  &kp D    &kp F      &kp G              &kp H          &kp J       &kp K      &kp L    &kp SEMI
-  &kp Z  &kp X  &kp C    &kp V      &kp B              &kp N          &kp M       &kp COMMA  &kp DOT  &kp FSLH
-                &td_win  &em 1 ESC  &hm LSHFT SPACE    &hm LCTRL RET  &em 4 BSPC  &kp TAB
+  &kp Q  &kp W  &kp E    &kp R            &kp T              &kp Y          &kp U          &kp I      &kp O    &kp P
+  &kp A  &kp S  &kp D    &kp F            &kp G              &kp H          &kp J          &kp K      &kp L    &kp SEMI
+  &kp Z  &kp X  &kp C    &kp V            &kp B              &kp N          &kp M          &kp COMMA  &kp DOT  &kp FSLH
+                &td_win  &lm WIN_NAV ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm CODE BSPC  &kp TAB
             >;
         };
 
@@ -238,10 +238,10 @@
             label = "MAC_DEF";
             display-name = "MacOS";
             bindings = <
-  &kp Q  &kp W  &kp E    &kp R      &kp T              &kp Y          &kp U       &kp I      &kp O    &kp P
-  &kp A  &kp S  &kp D    &kp F      &kp G              &kp H          &kp J       &kp K      &kp L    &kp SEMI
-  &kp Z  &kp X  &kp C    &kp V      &kp B              &kp N          &kp M       &kp COMMA  &kp DOT  &kp FSLH
-                &td_mac  &em 3 ESC  &hm LSHFT SPACE    &hm LCTRL RET  &em 4 BSPC  &kp TAB
+  &kp Q  &kp W  &kp E    &kp R            &kp T              &kp Y          &kp U          &kp I      &kp O    &kp P
+  &kp A  &kp S  &kp D    &kp F            &kp G              &kp H          &kp J          &kp K      &kp L    &kp SEMI
+  &kp Z  &kp X  &kp C    &kp V            &kp B              &kp N          &kp M          &kp COMMA  &kp DOT  &kp FSLH
+                &td_mac  &lm MAC_NAV ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm CODE BSPC  &kp TAB
             >;
         };
 


### PR DESCRIPTION
- 更新按鍵映射以將 `esc_mod` 更改為 `layer_mod` 以增加兼容性
- 將 `em` 替換為 `lm` 以在 Windows 和 macOS 變化中進行導航
- 調整 `em` 和 `lm` 在 Windows 和 macOS 配置上的不同功能的按鍵綁定。

Signed-off-by: HomePC <jackie@dast.tw>
