### PR TITLE
GIT 提交信息:

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -216,10 +216,10 @@
             label = "WIN_DEF";
             display-name = "Windows";
             bindings = <
-  &kp Q  &kp W  &kp E    &kp R            &kp T              &kp Y          &kp U          &kp I      &kp O    &kp P
-  &kp A  &kp S  &kp D    &kp F            &kp G              &kp H          &kp J          &kp K      &kp L    &kp SEMI
-  &kp Z  &kp X  &kp C    &kp V            &kp B              &kp N          &kp M          &kp COMMA  &kp DOT  &kp FSLH
-                &td_win  &lm WIN_NAV ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm CODE BSPC  &kp TAB
+  &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U             &kp I      &kp O    &kp P
+  &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J             &kp K      &kp L    &kp SEMI
+  &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M             &kp COMMA  &kp DOT  &kp FSLH
+                &td_win  &lm CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm WIN_NAV BSPC  &kp TAB
             >;
         };
 
@@ -238,10 +238,10 @@
             label = "MAC_DEF";
             display-name = "MacOS";
             bindings = <
-  &kp Q  &kp W  &kp E    &kp R            &kp T              &kp Y          &kp U          &kp I      &kp O    &kp P
-  &kp A  &kp S  &kp D    &kp F            &kp G              &kp H          &kp J          &kp K      &kp L    &kp SEMI
-  &kp Z  &kp X  &kp C    &kp V            &kp B              &kp N          &kp M          &kp COMMA  &kp DOT  &kp FSLH
-                &td_mac  &lm MAC_NAV ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm CODE BSPC  &kp TAB
+  &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U             &kp I      &kp O    &kp P
+  &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J             &kp K      &kp L    &kp SEMI
+  &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M             &kp COMMA  &kp DOT  &kp FSLH
+                &td_mac  &lm CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm MAC_NAV BSPC  &kp TAB
             >;
         };
 


### PR DESCRIPTION
重構: 為 Windows 和 Mac 重新設計鍵位分配和導航流程

- 更新 Windows 和 Mac 的按鍵映射
- 更改 Code 和 Win 導航模式下 ESC 鍵的功能
- 交換 `BS` 和 `TAB` 鍵的位置

Signed-off-by: HomePC <jackie@dast.tw>
