### PR TITLE
GIT 提交訊息：

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -8,10 +8,10 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
 
-#define WIN_DEF  0
-#define WIN_NAV  1
-#define MAC_DEF  2
-#define MAC_NAV  3
+#define WinDEF  0
+#define WinNAV  1
+#define MacDEF  2
+#define MacNAV  3
 #define CODE     4
 #define FUNC     5
 #define SYS      6
@@ -212,19 +212,19 @@
     keymap {
         compatible = "zmk,keymap";
 
-        WIN_DEF_layer {
-            label = "WIN_DEF";
+        WinDEF_layer {
+            label = "WinDEF";
             display-name = "Windows";
             bindings = <
-  &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U             &kp I      &kp O    &kp P
-  &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J             &kp K      &kp L    &kp SEMI
-  &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M             &kp COMMA  &kp DOT  &kp FSLH
-                &td_win  &lm CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm WIN_NAV BSPC  &kp TAB
+  &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
+  &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
+  &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
+                &td_win  &lm CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm WinNAV BSPC  &kp TAB
             >;
         };
 
-        WIN_NAV_layer {
-            label = "WIN_NAV";
+        WinNav_layer {
+            label = "WinNav";
             display-name = "WinNav";
             bindings = <
   &kp N1     &kp N2    &kp N3    &kp N4    &kp N5       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0
@@ -234,19 +234,19 @@
             >;
         };
 
-        MAC_DEF_layer {
-            label = "MAC_DEF";
+        MacDEF_layer {
+            label = "MacDEF";
             display-name = "MacOS";
             bindings = <
-  &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U             &kp I      &kp O    &kp P
-  &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J             &kp K      &kp L    &kp SEMI
-  &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M             &kp COMMA  &kp DOT  &kp FSLH
-                &td_mac  &lm CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm MAC_NAV BSPC  &kp TAB
+  &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
+  &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
+  &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
+                &td_mac  &lm CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm MacNAV BSPC  &kp TAB
             >;
         };
 
-        MAC_NAV_layer {
-            label = "MAC_NAV";
+        MacNAV_layer {
+            label = "MacNAV";
             display-name = "MacNav";
             bindings = <
   &kp N1     &kp N2    &kp N3    &kp N4    &kp N5       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0
@@ -271,10 +271,10 @@
             label = "FUNC";
             display-name = "Func";
             bindings = <
-  &kp F1  &kp F2  &kp F3  &kp F4  &kp F5    &kp F6       &kp F7       &kp F8   &kp F9   &kp F10
-  &none   &none   &none   &none   &none     &to WIN_DEF  &to MAC_DEF  &to SYS  &kp F11  &kp F12
-  &none   &none   &none   &none   &none     &none        &none        &none    &none    &none
-                  &trans  &trans  &trans    &trans       &trans       &trans
+  &kp F1  &kp F2  &kp F3  &kp F4  &kp F5    &kp F6      &kp F7      &kp F8   &kp F9   &kp F10
+  &none   &none   &none   &none   &none     &to WinDEF  &to MacDEF  &to SYS  &kp F11  &kp F12
+  &none   &none   &none   &none   &none     &none       &none       &none    &none    &none
+                  &trans  &trans  &trans    &trans      &trans      &trans
             >;
         };
 
@@ -283,7 +283,7 @@
             display-name = "System";
             bindings = <
   &none  &none  &none  &none  &bt BT_CLR     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-  &none  &none  &none  &none  &bootloader    &bootloader   &to WIN_DEF   &to MAC_DEF   &none         &none
+  &none  &none  &none  &none  &bootloader    &bootloader   &to WinDEF    &to MacDEF    &none         &none
   &none  &none  &none  &none  &sys_reset     &sys_reset    &none         &none         &none         &none
                 &none  &none  &none          &none         &none         &none
             >;


### PR DESCRIPTION
重構：標準化按鍵映射常數和層標籤

- 修改按鍵映射定義，更改“WinDEF”、“WinNAV”、“MacDEF”和“MacNAV”常數的大小寫
- 調整層標籤以使用更新後的按鍵映射常數（例如，“WinDEF_layer”改為“WinDEF_layer”）
- 更新“WinNAV”和“MacNAV”層的綁定，參考新的按鍵映射常數
- 重構“FUNC”層的綁定，以使用更新後的按鍵映射常數
- 通過將按鍵映射常數名稱與相應的層標籤對齊，引入一致性

Signed-off-by: HomePC <jackie@dast.tw>
