### PR TITLE
GIT 提交消息：

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -10,10 +10,10 @@
 
 // Layers
 
-#define WinDEF  0
-#define WinNAV  1
-#define MacDEF  2
-#define MacNAV  3
+#define WinDef  0
+#define WinNav  1
+#define MacDef  2
+#define MacNav  3
 #define CODE    4
 #define FUNC    5
 #define SYS     6
@@ -212,8 +212,8 @@
     keymap {
         compatible = "zmk,keymap";
 
-        WinDEF_layer {
-            label = "WinDEF";
+        WinDef_layer {
+            label = "WinDef";
             display-name = "Windows";
             bindings = <
   &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
@@ -234,8 +234,8 @@
             >;
         };
 
-        MacDEF_layer {
-            label = "MacDEF";
+        MacDef_layer {
+            label = "MacDef";
             display-name = "MacOS";
             bindings = <
   &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
@@ -245,8 +245,8 @@
             >;
         };
 
-        MacNAV_layer {
-            label = "MacNAV";
+        MacNav_layer {
+            label = "MacNav";
             display-name = "MacNav";
             bindings = <
   &kp N1     &kp N2    &kp N3    &kp N4    &kp N5       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0


### PR DESCRIPTION
重構：標準化層級定義和標籤

- 更正層級定義的大小寫（例如，WinDef、MacDef）
- 更新層級標籤以匹配更新後的定義（例如，WinDef_layer、MacDef_layer）
- 修正 Windows 和 MacOS 層的顯示名稱（例如，display-name = "Windows"、display-name = "MacOS"）
- 修改 MacNav_layer 的標籤以符合新的大小寫（例如，label = "MacNav"）
- 調整 Mac 層中的按鍵綁定

Signed-off-by: OfficePC <jackie@dast.tw>
