### PR TITLE
重構：標準化按鍵映射定義和層綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -14,8 +14,8 @@
 #define WinNav  1
 #define MacDef  2
 #define MacNav  3
-#define CODE    4
-#define FUNC    5
+#define Code    4
+#define Func    5
 #define SYS     6
 
 / {
@@ -219,7 +219,7 @@
   &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
   &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
   &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
-                &td_win  &lm CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm WinNAV BSPC  &kp TAB
+                &td_win  &lm Code ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm WinNav BSPC  &kp TAB
             >;
         };
 
@@ -241,7 +241,7 @@
   &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
   &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
   &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
-                &td_mac  &lm CODE ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm MacNAV BSPC  &kp TAB
+                &td_mac  &lm Code ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm MacNav BSPC  &kp TAB
             >;
         };
 
@@ -256,8 +256,8 @@
             >;
         };
 
-        CODE_layer {
-            label = "CODE";
+        Code_layer {
+            label = "Code";
             display-name = "Code";
             bindings = <
   &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR
@@ -267,14 +267,14 @@
             >;
         };
 
-        FUNC_layer {
-            label = "FUNC";
-            display-name = "FUNC";
+        Func_layer {
+            label = "Func";
+            display-name = "Func";
             bindings = <
-  &kp F1  &kp F2  &kp F3  &kp F4  &kp F5    &kp F6      &kp F7      &kp F8   &kp F9   &kp F10
-  &none   &none   &none   &none   &none     &to WinDEF  &to MacDEF  &to SYS  &kp F11  &kp F12
-  &none   &none   &none   &none   &none     &none       &none       &none    &none    &none
-                  &trans  &trans  &trans    &trans      &trans      &trans
+  &kp F1  &kp F2  &kp F3  &kp F4  &kp F5    &kp F6   &kp F7      &kp F8      &kp F9   &kp F10
+  &none   &none   &none   &none   &none     &to SYS  &to WinDef  &to MacDef  &kp F11  &kp F12
+  &none   &none   &none   &none   &none     &none    &none       &none       &none    &none
+                  &trans  &trans  &trans    &trans   &trans      &trans
             >;
         };
 
@@ -283,7 +283,7 @@
             display-name = "System";
             bindings = <
   &none  &none  &none  &none  &bt BT_CLR     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-  &none  &none  &none  &none  &bootloader    &bootloader   &to WinDEF    &to MacDEF    &none         &none
+  &none  &none  &none  &none  &bootloader    &bootloader   &to WinDef    &to MacDef    &none         &none
   &none  &none  &none  &none  &sys_reset     &sys_reset    &none         &none         &none         &none
                 &none  &none  &none          &none         &none         &none
             >;


### PR DESCRIPTION
- 將按鍵映射定義從 `CODE` 更新為 `Code`、`FUNC` 更新為 `Func`
- 修改不同層的按鍵綁定（`CODE_layer`、`FUNC_layer` 等）
- 調整層的顯示名稱以匹配更新後的按鍵映射定義

Signed-off-by: OfficePC <jackie@dast.tw>
