### PR TITLE
功能: 重構鍵盤映射配置和點擊設置

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -25,9 +25,9 @@
         hm: hold_mod {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
-            flavor = "hold-preferred";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <150>;
+            flavor = "tap-unless-interrupted";
+            tapping-term-ms = <100>;
+            quick-tap-ms = <200>;
             bindings = <&kp>, <&kp>;
 
             require-prior-idle-ms = <125>;


### PR DESCRIPTION
- 在角落鍵盤映射配置中更新行為設定
- 將風味更改為"輕觸除非中斷"
- 調整點擊間隔和快速點擊值
- 刪除過時的風味和點擊設置

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
