### PR TITLE
重構：更新觸控以及快速點擊的時間閾值

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -26,8 +26,8 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-unless-interrupted";
-            tapping-term-ms = <100>;
-            quick-tap-ms = <200>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <150>;
             bindings = <&kp>, <&kp>;
 
             require-prior-idle-ms = <125>;


### PR DESCRIPTION
- 將觸控時期（tapping-term-ms）從 <100 增加到 <200
- 將快速點擊時期（quick-tap-ms）從 <200 減少到 <150

Signed-off-by: OfficePC <jackie@dast.tw>
