### PR TITLE
特性：在所有文件中將按鍵映射風格更新為“tap-preferred”

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -25,7 +25,7 @@
         hm: hold_mod {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
-            flavor = "tap-unless-interrupted";
+            flavor = "tap-preferred";
             tapping-term-ms = <200>;
             quick-tap-ms = <150>;
             bindings = <&kp>, <&kp>;


### PR DESCRIPTION
- 將corne.keymap文件中的風格從“tap-unless-interrupted”更改為“tap-preferred”。

Signed-off-by: OfficePC <jackie@dast.tw>
