### PR TITLE
功能：重構corne.keymap中的按鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -22,14 +22,13 @@
     chosen { zmk,matrix_transform = &five_column_transform; };
 
     behaviors {
-        hm: hold_mod {
+        rm: row_mod {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";
             tapping-term-ms = <200>;
             quick-tap-ms = <150>;
             bindings = <&kp>, <&kp>;
-
             require-prior-idle-ms = <125>;
         };
 
@@ -239,7 +238,7 @@
   &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
   &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
   &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
-                &td_win  &lm Code ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm WinNav BSPC  &kp TAB
+                &td_win  &lm Code ESC  &rm LSHFT SPACE    &rm LCTRL RET  &lm WinNav BSPC  &kp TAB
             >;
         };
 
@@ -261,7 +260,7 @@
   &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
   &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
   &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
-                &td_mac  &lm Code ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm MacNav BSPC  &kp TAB
+                &td_mac  &lm Code ESC  &rm LSHFT SPACE    &rm LCTRL RET  &lm MacNav BSPC  &kp TAB
             >;
         };
 


### PR DESCRIPTION
- 在corne.keymap文件中，從"hold_mod"更新為"row_mod"的行為
- 修改corne.keymap文件中的移位和控制鍵綁定
- 用"lm"和"rm"調整corne.keymap文件中的WinNav和MacNav行為

Signed-off-by: HomePC <jackie@dast.tw>
