### PR TITLE
feat: 在配置文件中調整鍵綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -220,10 +220,10 @@
             label = "Func";
             display-name = "Func";
             bindings = <
-  &kp F1  &kp F2  &kp F3  &kp F4  &kp F5    &kp F6   &kp F7      &kp F8      &kp F9   &kp F10
-  &none   &none   &none   &none   &none     &to SYS  &to WinDef  &to MacDef  &kp F11  &kp F12
-  &none   &none   &none   &none   &none     &none    &none       &none       &none    &none
-                  &trans  &trans  &trans    &trans   &trans      &trans
+  &kp F1  &kp F2  &kp F3  &kp F4  &kp F5    &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
+  &none   &none   &none   &none   &none     &to SYS  &to WinDef     &to MacDef      &kp F11           &kp F12
+  &none   &none   &none   &none   &none     &none    &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+                  &trans  &trans  &trans    &trans   &trans         &trans
             >;
         };
 


### PR DESCRIPTION
- 修改`config/corne.keymap`中的鍵綁定，包括新增的鍵組合
- 為特定功能如LG(LC(D))和LG(LC(F4))添加鍵綁定

Signed-off-by: OfficePC <jackie@dast.tw>
