### PR TITLE
修正：重新配置數字鍵盤與大寫鎖定鍵的綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -176,10 +176,10 @@
             label = "WinNav";
             display-name = "WinNav";
             bindings = <
-  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0
-  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP    &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(TAB)
-  &ter_win       &none     &kp LG(DOWN)  &kp END   &kp PG_DN    &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LA(F9)
-                           &trans        &trans    &trans       &trans        &trans        &trans
+  &kp N1         &kp N2     &kp N3        &kp N4    &kp N5       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0
+  &kp LG(LS(S))  &kp CAPS   &kp LG(UP)    &kp HOME  &kp PG_UP    &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(TAB)
+  &ter_win       &kp LG(D)  &kp LG(DOWN)  &kp END   &kp PG_DN    &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LA(F9)
+                            &trans        &trans    &trans       &trans        &trans        &trans
             >;
         };
 


### PR DESCRIPTION
- 更新 N2 數字鍵盤按鍵的綁定為 LG(D)
- 更正大寫鎖定鍵的綁定為 LG(DOWN)

Signed-off-by: HomePC-WSL <jackie@dast.tw>
