### PR TITLE
作業: 更新 Corne 鍵圈配置中的預設輕點時間

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -37,7 +37,7 @@
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <200>;
-            quick-tap-ms = <0>;
+            quick-tap-ms = <200>;
             bindings = <&mo>, <&kp>;
         };
 


### PR DESCRIPTION
- 將 `config/corne.keymap` 檔案中的 `quick-tap-ms` 值更新為 200

Signed-off-by: HomePC-WSL <jackie@dast.tw>
