### PR TITLE
性能優化: 調整輸入時程參數以改善使用者互動

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -36,8 +36,8 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <200>;
+            tapping-term-ms = <500>;
+            quick-tap-ms = <120>;
             bindings = <&mo>, <&kp>;
         };
 


### PR DESCRIPTION
- 將點擊間隔時間（tapping-term-ms）從 200 調整為 500
- 將快速點擊時間（quick-tap-ms）從 200 調整為 120

Signed-off-by: HomePC-WSL <jackie@dast.tw>
