### PR TITLE
重構：重新設計巨集命名慣例

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -38,7 +38,7 @@
     };
 
     macros {
-        edge: brower_edge {
+        edge: start_edge {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             wait-ms = <0>;


### PR DESCRIPTION
- 將巨集名稱從&#34;browser_edge&#34;更改為&#34;start_edge&#34;

Signed-off-by: HomePC <jackie@dast.tw>
