### PR TITLE
明確授權條款並維護文檔超連結

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,25 @@
 ## 功能層
 
 ### 預設層 (Windows 和 MacOS)
+
 - **Windows Default (WinDef)**: 預設的 Windows 鍵盤佈局。
 - **MacOS Default (MacDef)**: 預設的 MacOS 鍵盤佈局。
 
 ### 導航層
+
 - **Windows Navigation (WinNav)**: 提供快速導航鍵，例如 Home、End、Page Up/Down。
 - **MacOS Navigation (MacNav)**: 提供 MacOS 特定的導航鍵。
 
 ### 程式碼層 (Code)
+
 - 包含常用符號和巨集，例如 `&kp EXCL`、`&kp HASH`。
 
 ### 功能層 (Func)
+
 - 提供功能鍵 (F1-F12) 和系統快捷鍵。
 
 ### 系統層 (SYS)
+
 - 包含藍牙配對、重置和啟動引導模式的快捷鍵。
 
 ## 巨集功能
@@ -39,11 +44,14 @@
 
 1. 確保已安裝 [ZMK](https://zmk.dev/) 開發環境。
 2. 將此專案克隆到本地：
+
    ```bash
    git clone https://github.com/你的帳號/corne-wireless-5-col-view-zmk-config.git
 
    ```
+
 3. 編譯並燒錄到你的 Corne 鍵盤：
+
    ```bash
    west build -p -b corne_left -- -DZMK_CONFIG=$(pwd)/config
    west flash
@@ -51,11 +59,16 @@
    ```
 
 ## 貢獻
+
 歡迎提交 Issue 或 Pull Request！請遵循以下步驟：
 
 ## Fork 此專案。
+
 創建一個新分支：
 提交更改並推送到你的分支。
 發送 Pull Request。
-授權
-此專案基於 MIT 授權條款，詳見 [LICENSE](https://github.com/cloverdefa/corne-wireless-5-col-view-zmk-config/blob/main/LICENSE.md) 文件。
+
+## 授權
+
+此專案基於 MIT 授權條款，詳見[MIT License](https://github.com/cloverdefa/corne-wireless-5-col-view-zmk-config/blob/main/LICENSE.md) 授權條款。
+


### PR DESCRIPTION
feat: 增強 Windows 和 MacOS 的鍵盤佈局及導航

- 為 Windows 和 MacOS 鍵盤佈局新增額外的預設層
- 為 Windows 和 MacOS 引入導航層
- 擴展代碼層以包含常用符號和巨集
- 強化功能層，增加功能鍵和系統快捷鍵
- 引入系統層快捷鍵以用於藍牙配對和啟動模式
- 更新問題和拉取請求的貢獻指南
- 新增一個授權資訊部分，並附上 MIT 授權的連結

Signed-off-by: HomePC-WSL <jackie@dast.tw>
