### PR TITLE
簡化鍵盤綁定並增強跨平台的一致性

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -21,22 +21,6 @@
 / {
     chosen { zmk,matrix_transform = &five_column_transform; };
 
-    behaviors {
-        td_win: td_win {
-            compatible = "zmk,behavior-tap-dance";
-            #binding-cells = <0>;
-            tapping-term-ms = <200>;
-            bindings = <&kp LALT>, <&kp LWIN>;
-        };
-
-        td_mac: td_mac {
-            compatible = "zmk,behavior-tap-dance";
-            #binding-cells = <0>;
-            tapping-term-ms = <200>;
-            bindings = <&kp LCMD>, <&kp LALT>;
-        };
-    };
-
     macros {
         edge: start_edge {
             compatible = "zmk,behavior-macro";
@@ -163,10 +147,10 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-  &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
-  &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
-  &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
-                &td_win  &lt Code ESC  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &kp TAB
+  &kp Q  &kp W  &kp E         &kp R     &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
+  &kp A  &kp S  &kp D         &kp F     &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
+  &kp Z  &kp X  &kp C         &kp V     &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
+                &mt LALT ESC  &mo Code  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &kp TAB
             >;
         };
 
@@ -185,10 +169,10 @@
             label = "MacDef";
             display-name = "MacOS";
             bindings = <
-  &kp Q  &kp W  &kp E    &kp R         &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
-  &kp A  &kp S  &kp D    &kp F         &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
-  &kp Z  &kp X  &kp C    &kp V         &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
-                &td_mac  &lt Code ESC  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp TAB
+  &kp Q  &kp W  &kp E         &kp R     &kp T              &kp Y          &kp U            &kp I      &kp O    &kp P
+  &kp A  &kp S  &kp D         &kp F     &kp G              &kp H          &kp J            &kp K      &kp L    &kp SEMI
+  &kp Z  &kp X  &kp C         &kp V     &kp B              &kp N          &kp M            &kp COMMA  &kp DOT  &kp FSLH
+                &mt LCMD ESC  &mo Code  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp TAB
             >;
         };
 
@@ -218,10 +202,10 @@
             label = "Func";
             display-name = "Func";
             bindings = <
-  &kp F1  &kp F2  &kp F3  &kp F4  &kp F5    &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
-  &none   &none   &none   &none   &none     &to SYS  &to WinDef     &to MacDef      &kp F11           &kp F12
-  &none   &edge   &none   &none   &none     &none    &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
-                  &trans  &trans  &trans    &trans   &trans         &trans
+  &kp F1      &kp F2  &kp F3  &kp F4  &kp F5    &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
+  &none       &none   &none   &none   &none     &to SYS  &to WinDef     &to MacDef      &kp F11           &kp F12
+  &kp(LG(I))  &edge   &none   &none   &none     &none    &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+                      &trans  &trans  &trans    &trans   &trans         &trans
             >;
         };
 


### PR DESCRIPTION
功能：簡化鍵盤綁定並增強跨平台的一致性

- 移除 Windows 和 Mac 上的點擊舞蹈行為
- 更新特定功能的鍵盤綁定
- 調整邊緣和選項卡功能的鍵位分配

Signed-off-by: HomePC-WIN <jackie@dast.tw>
