### PR TITLE
重構鍵位綁定以提高清晰度和可用性

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -202,10 +202,10 @@
             label = "Func";
             display-name = "Func";
             bindings = <
-  &kp F1      &kp F2  &kp F3  &kp F4  &kp F5    &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
-  &none       &none   &none   &none   &none     &to SYS  &to WinDef     &to MacDef      &kp F11           &kp F12
-  &kp(LG(I))  &edge   &none   &none   &none     &none    &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
-                      &trans  &trans  &trans    &trans   &trans         &trans
+  &kp F1      &kp F2    &kp F3  &kp F4  &kp F5    &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
+  &none       &none     &none   &none   &none     &to SYS  &to WinDef     &to MacDef      &kp F11           &kp F12
+  &kp(LG(I))  &sk LWIN  &none   &none   &none     &none    &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+                        &trans  &trans  &trans    &trans   &trans         &trans
             >;
         };
 


### PR DESCRIPTION
重構: 重構鍵位綁定以提高清晰度和可用性

- 將一個鍵的映射從 &amp;edge 更改為 &amp;sk LWIN
- 沒有移除任何功能，但對鍵位綁定進行了修改，以提高清晰度和功能性。

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
