### PR TITLE
標準化配置文件的鍵位綁定

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -202,10 +202,10 @@
             label = "Func";
             display-name = "Func";
             bindings = <
-  &kp F1      &kp F2    &kp F3  &kp F4  &kp F5    &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
-  &none       &none     &none   &none   &none     &to SYS  &to WinDef     &to MacDef      &kp F11           &kp F12
-  &kp(LG(I))  &sk LWIN  &none   &none   &none     &LA(F4)  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
-                        &trans  &trans  &trans    &trans   &trans         &trans
+  &kp F1      &kp F2    &kp F3  &kp F4  &kp F5    &kp F6      &kp F7         &kp F8          &kp F9            &kp F10
+  &none       &none     &none   &none   &none     &to SYS     &to WinDef     &to MacDef      &kp F11           &kp F12
+  &kp(LG(I))  &sk LWIN  &none   &none   &none     &kp LA(F4)  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+                        &trans  &trans  &trans    &trans      &trans         &trans
             >;
         };
 


### PR DESCRIPTION
樣式：標準化配置文件的鍵位綁定

- 調整配置文件中的鍵位綁定以保持一致性。

Signed-off-by: OfficePC <jackie@dast.tw>
