### PR TITLE
重構 tmux 鍵位綁定配置

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -118,13 +118,13 @@
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A) &kp PIPE>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp D>;
         };
 
         row: tmux_row {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A) &kp MINUS>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp LS(D)>;
         };
 
         list: tmux_list {


### PR DESCRIPTION
chore: 重構 tmux 鍵位綁定配置

- 更新 tmux 欄位配置的鍵位綁定
- 修改 tmux 行配置的鍵位綁定

Signed-off-by: DAST <jackie@dast.tw>
