### PR TITLE
重新整理鍵位綁定以增強巨集相容性

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -118,13 +118,13 @@
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A) &kp D>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp PIPE>;
         };
 
         row: tmux_row {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A) &kp LS(D)>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp MINUS>;
         };
 
         list: tmux_list {


### PR DESCRIPTION
feat：重新整理鍵位綁定以增強巨集相容性

- 更新鍵位綁定，使用 PIPE 和 MINUS 代替 D 和 LS(D)
- 維持與 zmk 行為的相容性以確保巨集功能

Signed-off-by: DAST <jackie@dast.tw>
