### PR TITLE
GIT 提交信息：

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -205,7 +205,7 @@
             display-name = "Func";
             bindings = <
   &kp F1      &kp F2        &kp F3  &kp F4  &kp F5     &kp F6           &kp F7         &kp F8          &kp F9            &kp F10
-  &sk LWIN    &sk LALT      &none   &none   &kp LA(C)  &to SYS          &to WinDef     &to MacDef      &kp F11           &kp F12
+  &sk LWIN    &none         &none   &none   &kp LA(C)  &to SYS          &to WinDef     &to MacDef      &kp F11           &kp F12
   &kp(LG(I))  &openbrowser  &none   &none   &none      &kp LC(LA(DEL))  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
                             &trans  &trans  &trans     &trans           &trans         &trans
             >;


### PR DESCRIPTION
修正：完善 LALT 和 LWIN 配置的鍵位綁定

- 修改 LALT 鍵的綁定，將其移除以採用默認操作
- 調整 LWIN 鍵的綁定，將其從 LALT 更改為無
- 對其他鍵的現有綁定保持不變

Signed-off-by: WSL <jackie@dast.tw>
