### PR TITLE
重構：重新排列功能鍵綁定以提升佈局一致性

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -206,8 +206,8 @@
             display-name = "Func";
             bindings = <
   &kp F1      &kp F2        &kp F3  &kp F4  &kp F5     &kp F6           &kp F7         &kp F8          &kp F9            &kp F10
-  &sk LWIN    &none         &none   &none   &kp LA(C)  &to SYS          &to WinDef     &to MacDef      &kp F11           &kp F12
-  &kp(LG(I))  &openbrowser  &none   &none   &none      &kp LC(LA(DEL))  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+  &sk LWIN    &none         &none   &none   &kp LA(C)  &to SYS          &to WinDef     &to MacDef      &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+  &kp(LG(I))  &openbrowser  &none   &none   &none      &kp LC(LA(DEL))  &kp LG(LC(D))  &kp LG(LC(F4))  &kp F11           &kp F12
                             &trans  &trans  &trans     &trans           &trans         &trans
             >;
         };


### PR DESCRIPTION
- 調整鍵綁定，交換部分功能鍵與修飾鍵組合的位置，以達到更佳的佈局一致性。

Signed-off-by: WSL <jackie@dast.tw>
