### PR TITLE
docs: 改善專案可用性的文件與視覺呈現

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 
 ## 專案結構與模組
 - `config/corne.keymap`：主要層（WinDef/MacDef/WinNav/MacNav/Code/Func/SYS）、combos 與巨集定義。
-- `config/corne.conf`：藍牙/省電/去彈跳與 ZMK Studio 設定。
-- `config/west.yml`：ZMK 專案 manifest（追蹤 `zmk` main）。
-- `build.yaml`：CI 建置矩陣（left/right + nice!view + Studio snippet）。
+- `config/corne.conf`：藍牙/省電/去彈跳與（可選）ZMK Studio 設定。
+- `config/west.yml`：ZMK 專案 manifest（目前固定 `zmk` v0.3）。
+- `build.yaml`：CI 建置矩陣（left/right + nice!view；Studio snippet 預設註解，可視需求啟用）。
 - `README.md`：使用說明與層概覽。
 
 ## 建置、測試與開發
@@ -17,15 +17,15 @@ west init -l config && west update
 # 左半
 west build -s zmk/app -d build/left -b nice_nano_v2 -- \
   -DSHIELD="corne_left nice_view_adapter nice_view" \
-  -DZMK_CONFIG=$PWD/config -DSNIPPET=studio-rpc-usb-uart
+  -DZMK_CONFIG=$PWD/config
 west flash -d build/left
 # 右半
 west build -s zmk/app -d build/right -b nice_nano_v2 -- \
   -DSHIELD="corne_right nice_view_adapter nice_view" \
-  -DZMK_CONFIG=$PWD/config -DSNIPPET=studio-rpc-usb-uart
+  -DZMK_CONFIG=$PWD/config
 west flash -d build/right
 ```
-說明：以上指令會建置左右半，啟用 nice!view 與 Studio RPC，並使用本倉庫的 `config/`。
+說明：以上指令會建置左右半並啟用 nice!view，使用本倉庫的 `config/`。若需啟用 ZMK Studio，請於兩側指令尾端加入 `-DSNIPPET=studio-rpc-usb-uart`。
 
 ## 程式風格與命名
 - Devicetree/DTS：4 空白縮排；保持 10 鍵列對齊，易讀優先。
@@ -51,4 +51,3 @@ west flash -d build/right
 ## 安全與設定提示（可選）
 - 勿提交個人配對資料；變更 `west.yml` 版本需說明理由。
 - `CONFIG_ZMK_STUDIO_LOCKING` 調整請審慎評估以免影響 Studio 使用。
-

--- a/IMG/code.svg
+++ b/IMG/code.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="740" height="300" viewBox="0 0 740 300">
+  <style>
+    .key { fill: #f7f7f7; stroke: #bbb; rx: 8; ry: 8; }
+    .label { font-family: system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, sans-serif; font-size: 13px; fill: #222; dominant-baseline: middle; text-anchor: middle; }
+    .title { font-size: 16px; font-weight: 700; fill: #333; }
+  </style>
+  <text x="10" y="20" class="title">Code</text>
+  <g transform="translate(10,30)">
+    <!-- row 1 -->
+    <g>
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">!</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">@</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">#</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">$</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">%</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">^</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">&amp;</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">*</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">(</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">)</text></g>
+    </g>
+    <!-- row 2 -->
+    <g transform="translate(0,70)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">list</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">col</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">`</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">-</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">=</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">[</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">]</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">'</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">"</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Alt+F4</text></g>
+    </g>
+    <!-- row 3 -->
+    <g transform="translate(0,140)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">tabs</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">row</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">~</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">+</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">_</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">[</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">]</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">|</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">\</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Del</text></g>
+    </g>
+    <!-- thumbs row -->
+    <g transform="translate(150,210)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Ctrl+Shift+↑</text></g>
+    </g>
+  </g>
+</svg>
+

--- a/IMG/func.svg
+++ b/IMG/func.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="740" height="300" viewBox="0 0 740 300">
+  <style>
+    .key { fill: #f7f7f7; stroke: #bbb; rx: 8; ry: 8; }
+    .label { font-family: system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, sans-serif; font-size: 12px; fill: #222; dominant-baseline: middle; text-anchor: middle; }
+    .title { font-size: 16px; font-weight: 700; fill: #333; }
+  </style>
+  <text x="10" y="20" class="title">Func</text>
+  <g transform="translate(10,30)">
+    <!-- row 1 -->
+    <g>
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F1</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F2</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F3</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F4</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F5</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F6</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F7</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F8</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F9</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F10</text></g>
+    </g>
+    <!-- row 2 -->
+    <g transform="translate(0,70)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">SK(Win)</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Alt+C</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">To(SYS)</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">To(WinDef)</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">To(MacDef)</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Win+Ctrl+←</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Win+Ctrl+→</text></g>
+    </g>
+    <!-- row 3 -->
+    <g transform="translate(0,140)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Win+I</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">OpenBrowser</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Ctrl+Alt+Del</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Win+Ctrl+D</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Win+Ctrl+F4</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F11</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F12</text></g>
+    </g>
+    <!-- thumbs row -->
+    <g transform="translate(150,210)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">TRNS</text></g>
+    </g>
+  </g>
+</svg>
+

--- a/IMG/macdef.svg
+++ b/IMG/macdef.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="740" height="300" viewBox="0 0 740 300">
+  <style>
+    .key { fill: #f7f7f7; stroke: #bbb; rx: 8; ry: 8; }
+    .label { font-family: system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, sans-serif; font-size: 14px; fill: #222; dominant-baseline: middle; text-anchor: middle; }
+    .title { font-size: 16px; font-weight: 700; fill: #333; }
+  </style>
+  <text x="10" y="20" class="title">MacDef</text>
+  <g transform="translate(10,30)">
+    <!-- row 1 -->
+    <g>
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Q</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">W</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">E</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">R</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">T</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Y</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">U</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">I</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">O</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">P</text></g>
+    </g>
+    <!-- row 2 -->
+    <g transform="translate(0,70)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">A</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">S</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">D</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">G</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">H</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">J</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">K</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">L</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">;</text></g>
+    </g>
+    <!-- row 3 -->
+    <g transform="translate(0,140)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Z</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">X</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">C</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">V</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">B</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">N</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">M</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">,</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">.</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">/</text></g>
+    </g>
+    <!-- thumbs row -->
+    <g transform="translate(150,210)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Cmd/Esc</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">MO(Code)</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Shift/Space</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Ctrl/Enter</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">LT(MacNav/Bksp)</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Tab</text></g>
+    </g>
+  </g>
+</svg>
+

--- a/IMG/sys.svg
+++ b/IMG/sys.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="740" height="300" viewBox="0 0 740 300">
+  <style>
+    .key { fill: #f7f7f7; stroke: #bbb; rx: 8; ry: 8; }
+    .label { font-family: system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, sans-serif; font-size: 12px; fill: #222; dominant-baseline: middle; text-anchor: middle; }
+    .title { font-size: 16px; font-weight: 700; fill: #333; }
+  </style>
+  <text x="10" y="20" class="title">SYS</text>
+  <g transform="translate(10,30)">
+    <!-- row 1 -->
+    <g>
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">BT_CLR</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">BT0</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">BT1</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">BT2</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">BT3</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">BT4</text></g>
+    </g>
+    <!-- row 2 -->
+    <g transform="translate(0,70)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Bootloader</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Bootloader</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">To(WinDef)</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">To(MacDef)</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+    </g>
+    <!-- row 3 -->
+    <g transform="translate(0,140)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Reset</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Reset</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+    </g>
+    <!-- thumbs row -->
+    <g transform="translate(150,210)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">—</text></g>
+    </g>
+  </g>
+</svg>
+

--- a/IMG/windef.svg
+++ b/IMG/windef.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="740" height="300" viewBox="0 0 740 300">
+  <style>
+    .key { fill: #f7f7f7; stroke: #bbb; rx: 8; ry: 8; }
+    .label { font-family: system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, sans-serif; font-size: 14px; fill: #222; dominant-baseline: middle; text-anchor: middle; }
+    .title { font-size: 16px; font-weight: 700; fill: #333; }
+  </style>
+  <text x="10" y="20" class="title">WinDef</text>
+  <!-- rows -->
+  <g transform="translate(10,30)">
+    <!-- row 1 -->
+    <g transform="translate(0,0)">
+      <!-- 10 keys -->
+      <!-- positions x: 0..9 * (60+10) -->
+      <g>
+        <rect class="key" x="0" y="0" width="60" height="60"/>
+        <text class="label" x="30" y="30">Q</text>
+      </g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">W</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">E</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">R</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">T</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Y</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">U</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">I</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">O</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">P</text></g>
+    </g>
+    <!-- row 2 -->
+    <g transform="translate(0,70)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">A</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">S</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">D</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">F</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">G</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">H</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">J</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">K</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">L</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">;</text></g>
+    </g>
+    <!-- row 3 -->
+    <g transform="translate(0,140)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Z</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">X</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">C</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">V</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">B</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">N</text></g>
+      <g transform="translate(420,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">M</text></g>
+      <g transform="translate(490,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">,</text></g>
+      <g transform="translate(560,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">.</text></g>
+      <g transform="translate(630,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">/</text></g>
+    </g>
+    <!-- thumbs row (6 keys centered) -->
+    <g transform="translate(150,210)">
+      <g><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Alt/Esc</text></g>
+      <g transform="translate(70,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">MO(Code)</text></g>
+      <g transform="translate(140,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Shift/Space</text></g>
+      <g transform="translate(210,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Ctrl/Enter</text></g>
+      <g transform="translate(280,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">LT(WinNav/Bksp)</text></g>
+      <g transform="translate(350,0)"><rect class="key" width="60" height="60"/><text class="label" x="30" y="30">Tab</text></g>
+    </g>
+  </g>
+</svg>
+

--- a/README.md
+++ b/README.md
@@ -1,74 +1,68 @@
 # Corne Wireless 5-Column View ZMK Config
 
-這是一個為 Corne 無線鍵盤設計的 ZMK 配置，支援 5 列鍵盤視圖，並包含多種功能層和自定義巨集。
+此倉庫為 Corne 無線鍵盤的 ZMK 設定，採用 5 列鍵位視圖，提供多層佈局與常用巨集，並可選配 nice!view 顯示與 ZMK Studio。
 
-## 目錄結構
+## 專案結構
 
-- **`config/`**: 包含 ZMK 的主要配置檔案，例如 `corne.keymap`。
-- **`behaviors.dtsi`**: 定義自定義行為。
-- **`macros/`**: 包含巨集的定義。
+- `config/corne.keymap`：主要層（WinDef/MacDef/WinNav/MacNav/Code/Func/SYS）、combos 與巨集定義。
+- `config/corne.conf`：藍牙、省電、去彈跳與（可選）Studio 設定。
+- `config/west.yml`：ZMK 專案 manifest（目前固定 `zmk` v0.3）。
+- `build.yaml`：CI 建置矩陣（left/right + nice!view；Studio snippet 可選）。
 
-## 功能層
+## 層與巨概覽
 
-### 預設層 (Windows 和 MacOS)
+- 預設層：`WinDef`、`MacDef`
+- 導航層：`WinNav`、`MacNav`
+- 其他層：`Code`、`Func`、`SYS`
+- 主要巨集：`ter_win`、`ter_mac`、`max_mac`、`rec_mac`
 
-- **Windows Default (WinDef)**: 預設的 Windows 鍵盤佈局。
-- **MacOS Default (MacDef)**: 預設的 MacOS 鍵盤佈局。
+## 鍵位圖
 
-### 導航層
+下列為主要層的鍵位示意（5 列視圖）：
 
-- **Windows Navigation (WinNav)**: 提供快速導航鍵，例如 Home、End、Page Up/Down。
-- **MacOS Navigation (MacNav)**: 提供 MacOS 特定的導航鍵。
+![WinDef](IMG/windef.svg)
 
-### 程式碼層 (Code)
+![MacDef](IMG/macdef.svg)
 
-- 包含常用符號和巨集，例如 `&kp EXCL`、`&kp HASH`。
+![Code](IMG/code.svg)
 
-### 功能層 (Func)
+![Func](IMG/func.svg)
 
-- 提供功能鍵 (F1-F12) 和系統快捷鍵。
+![SYS](IMG/sys.svg)
 
-### 系統層 (SYS)
+## 建置與燒錄
 
-- 包含藍牙配對、重置和啟動引導模式的快捷鍵。
+前置：安裝 Zephyr SDK 與 West，並以本倉庫 `config/` 作為 ZMK 設定。
 
-## 巨集功能
+```bash
+west init -l config && west update
+# 左半
+west build -s zmk/app -d build/left -b nice_nano_v2 -- \
+  -DSHIELD="corne_left nice_view_adapter nice_view" \
+  -DZMK_CONFIG=$PWD/config
+west flash -d build/left
+# 右半
+west build -s zmk/app -d build/right -b nice_nano_v2 -- \
+  -DSHIELD="corne_right nice_view_adapter nice_view" \
+  -DZMK_CONFIG=$PWD/config
+west flash -d build/right
+```
 
-- **`ter_win`**: 開啟 Windows Terminal。
-- **`ter_mac`**: 開啟 MacOS Terminal。
-- **`max_mac`**: 最大化視窗 (MacOS)。
-- **`min_mac`**: 最小化視窗 (MacOS)。
-- **`rec_mac`**: 開始螢幕錄影 (MacOS)。
+- 若需啟用 ZMK Studio，可在上述兩側指令尾端加上 `-DSNIPPET=studio-rpc-usb-uart`。
+- CI 版本參考 `build.yaml`；其中 Studio snippet 預設為註解（可視需求啟用）。
 
-## 安裝與使用
+## 驗證重點
 
-1. 確保已安裝 [ZMK](https://zmk.dev/) 開發環境。
-2. 將此專案克隆到本地：
+- 層切換：`Code`/`Func`/`SYS`（`&mo`, `&to`）行為正確。
+- 巨集：`ter_win`、`ter_mac`、`max_mac`、`rec_mac` 正常執行。
+- 藍牙：`&bt BT_SEL n`、`&bt BT_CLR`；喚醒/睡眠（`CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`）。
+- 顯示：nice!view 能正常刷新。
 
-   ```bash
-   git clone https://github.com/你的帳號/corne-wireless-5-col-view-zmk-config.git
+## 貢獻指南
 
-   ```
-
-3. 編譯並燒錄到你的 Corne 鍵盤：
-
-   ```bash
-   west build -p -b corne_left -- -DZMK_CONFIG=$(pwd)/config
-   west flash
-
-   ```
-
-## 貢獻
-
-歡迎提交 Issue 或 Pull Request！請遵循以下步驟：
-
-## Fork 此專案。
-
-創建一個新分支：
-提交更改並推送到你的分支。
-發送 Pull Request。
+- Commit 建議使用 Conventional Commits：`feat:`, `fix:`, `refactor:`, `build:`, `ci:` 等。
+- 每次提交專注單一更動，PR 提供變更摘要、關鍵片段（前/後）或鍵位圖、以及本地驗證步驟。
 
 ## 授權
 
-此專案基於 MIT 授權條款，詳見[MIT License](https://github.com/cloverdefa/corne-wireless-5-col-view-zmk-config/blob/main/LICENSE.md) 授權條款。
-
+本專案採用 MIT 授權，詳見 `LICENSE.md`。


### PR DESCRIPTION
- 精煉專案結構描述以提升清晰度，並更新設定檔中的版本資訊。
- 調整建置指示，預設不包含 Studio RPC 片段，並新增說明如何明確啟用該功能。
- 新增多個不同層級（Code、Func、MacDef、SYS、WinDef）的 SVG 鍵盤配置圖，方便視覺化鍵位布局。
- 修訂 README，改善專案概述、層級總結、建置指示及貢獻指南。
- 在驗證區段新增更明確的層級切換、巨集、藍牙功能與 nice!view 顯示操作指引。
- 更新貢獻流程，推薦使用 Conventional Commits 並提供詳細的 PR 建議。
- 全文進行輕微格式及用詞優化。

Signed-off-by: WSL <jackie@dast.tw>
