### PR TITLE
refactor: 重構子程序命令以使用格式化的檔案路徑

### DIFF
--- a/drawer.py
+++ b/drawer.py
@@ -8,14 +8,14 @@ def main():
     svg_file = base_dir / "IMG/corne.svg"
     svg_file.parent.mkdir(parents=True, exist_ok=True)
 
-    subprocess.run(
-        "keymap parse -c 10 -z ./config/corne.keymap > corne_keymap.yaml",
-        shell=True,
-        check=True,
-    )
-    subprocess.run(
-        "keymap draw corne_keymap.yaml > IMG/corne.svg", shell=True, check=True
-    )
+    # parse -> YAML
+    parse_cmd = f'keymap parse -c 10 -z ./config/corne.keymap > "{yaml_file}"'
+    subprocess.run(parse_cmd, shell=True, check=True)
+
+    # draw -> SVG
+    draw_cmd = f'keymap draw "{yaml_file}" > "{svg_file}"'
+    subprocess.run(draw_cmd, shell=True, check=True)
+
     print(f"✅ 已生成 SVG: {svg_file}")
 
 


### PR DESCRIPTION
- 重構子程序命令，改用帶有明確 YAML 與 SVG 檔案路徑的格式化字串，取代硬編碼的檔名。

Signed-off-by: WSL <jackie@dast.tw>
