### PR TITLE
修正：處理在按下 Enter 前有延遲的分割按鍵序列

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -71,7 +71,9 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
+                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y>,
+                <&macro_wait_time 500>,
+                <&kp RET>;
         };
 
        max_mac: windowmax_mac {


### PR DESCRIPTION
- 將組合按鍵序列拆分為獨立按鍵，並在按下 Enter 前增加 500 毫秒等待時間。

Signed-off-by: Macbook Air <jackie@dast.tw>
