### PR TITLE
feat: 修正並標準化 ESC 鍵標籤及圖層切換按鍵

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1091,6 +1091,7 @@ path.combo {
 <g transform="translate(0, 56)">
 <g transform="translate(28, 49)" class="key keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">ESC</text>
 </g>
 <g transform="translate(84, 35)" class="key keypos-1">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1199,14 +1200,14 @@ path.combo {
 </g>
 <g transform="translate(168, 205)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
+<a href="#MacOS">
+<text x="0" y="0" class="key tap layer-activator">MacOS</text>
 </a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(230, 213) rotate(15.0)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
 </a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(295, 224) rotate(30.0)" class="key keypos-32">

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -225,10 +225,10 @@
             label = "Mouse";
             display-name = "Mouse";
             bindings = <
-  &none  &none  &none    &none       &none         &none           &none           &none         &none            &none
-  &none  &none  &none    &none       &none         &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none
-  &none  &none  &none    &none       &none         &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none
-                &to SYS  &to MacDef  &to WinDef    &mkp LCLK       &mkp RCLK       &mkp MCLK
+  &kp ESC  &none  &none       &none    &none         &none           &none           &none         &none            &none
+  &none    &none  &none       &none    &none         &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none
+  &none    &none  &none       &none    &none         &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none
+                  &to MacDef  &to SYS  &to WinDef    &mkp LCLK       &mkp RCLK       &mkp MCLK
             >;
         };
 


### PR DESCRIPTION
- 在 SVG 佈局中對應按鍵上新增 ESC 鍵標籤。
- 交換 SVG 中 System 與 MacOS 圖層切換按鍵的標籤及連結。
- 將 Mouse 圖層中 ESC 鍵的綁定從無改為 ESC。
- 交換 Keymap 綁定中 System 與 MacOS 圖層切換按鍵的順序。

Signed-off-by: WSL <jackie@dast.tw>
