### PR TITLE
feat: 強化 SVG 佈局，新增互動式滑鼠按鍵標籤

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1029,6 +1029,9 @@ path.combo {
 </g>
 <g transform="translate(252, 154)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Mouse">
+<text x="0" y="0" class="key tap layer-activator">Mouse</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(476, 154)" class="key keypos-25">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1071,11 +1074,9 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(433, 224) rotate(-30.0)" class="key keypos-33">
-<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
-<a href="#Mouse">
-<text x="0" y="0" class="key tap layer-activator">Mouse</text>
-</a><text x="0" y="38" class="key hold">toggle</text>
+<g transform="translate(433, 224) rotate(-30.0)" class="key trans keypos-33">
+<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g transform="translate(498, 213) rotate(-15.0)" class="key held keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -216,8 +216,8 @@
             bindings = <
   &kp F1      &kp F2        &kp F3  &kp F4  &kp F5       &kp F6           &kp F7         &kp F8          &kp F9            &kp F10
   &sk LWIN    &none         &none   &none   &kp LA(C)    &to SYS          &to WinDef     &to MacDef      &kp F11           &kp F12
-  &kp(LG(I))  &openbrowser  &none   &none   &none        &kp LC(LA(DEL))  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
-                            &trans  &trans  &trans       &to Mouse           &trans         &trans
+  &kp(LG(I))  &openbrowser  &none   &none   &to Mouse    &kp LC(LA(DEL))  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+                            &trans  &trans  &trans       &trans           &trans         &trans
             >;
         };
 


### PR DESCRIPTION
- 在 SVG 佈局中新增可點擊的「滑鼠」按鍵標籤，並可切換顯示文字。
- 將部分 SVG 中的按鍵元素從靜態改為透明過渡，並新增向下箭頭標籤。
- 更新按鍵映射，將「切換到滑鼠」操作提早至綁定序列中，並相應調整周邊過渡效果。

Signed-off-by: WSL <jackie@dast.tw>
