### PR TITLE
perf: 將按鍵序列拆分，在回車鍵前插入延遲

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -61,7 +61,9 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp T &kp RET>;
+                <&kp W &kp T>,
+                <&macro_wait_time 500>,
+                <&kp RET>;
         };
 
         ter_mac: terminal_macos {


### PR DESCRIPTION
- 將單一按鍵序列拆分為分開的按鍵操作，並在巨集中回車鍵前插入 500 毫秒的延遲。

Signed-off-by: Macbook Air <jackie@dast.tw>
