### PR TITLE
refactor：重新排列並重新標記 keymap SVG 中的圖層選擇鍵

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1305,15 +1305,9 @@ path.combo {
 </g>
 <g transform="translate(532, 91)" class="key keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(588, 84)" class="key keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(644, 91)" class="key keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1364,12 +1358,21 @@ path.combo {
 </g>
 <g transform="translate(433, 224) rotate(-30.0)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
+<a href="#MacOS">
+<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+</a><text x="0" y="38" class="key hold">toggle</text>
 </g>
 <g transform="translate(498, 213) rotate(-15.0)" class="key keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Mouse">
+<text x="0" y="0" class="key tap layer-activator">Mouse</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(560, 205)" class="key keypos-35">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Windows">
+<text x="0" y="0" class="key tap layer-activator">Windows</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -239,9 +239,9 @@
             display-name = "System";
             bindings = <
   &none  &none  &none  &none  &bt BT_CLR     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-  &none  &none  &none  &none  &bootloader    &bootloader   &to WinDef    &to MacDef    &none         &none
+  &none  &none  &none  &none  &bootloader    &bootloader   &none         &none         &none         &none
   &none  &none  &none  &none  &sys_reset     &sys_reset    &none         &none         &none         &none
-                &none  &none  &none          &none         &none         &none
+                &none  &none  &none          &to MacDef    &to Mouse     &to WinDef
             >;
         };
     };


### PR DESCRIPTION
- 從 SVG 的頂排按鍵中移除 Windows 和 MacOS 圖層選擇標籤
- 在 SVG 斜角鍵群中新增標示 MacOS、滑鼠及 Windows 圖層選擇的按鍵
- 更新 keymap 配置，移除一排中的 Windows 與 MacOS 圖層切換鍵，並在另一位置新增 MacOS、滑鼠及 Windows 圖層切換鍵

Signed-off-by: WSL <jackie@dast.tw>
