### PR TITLE
feat: 新增 spotlight 巨集並相應更新鍵盤綁定

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1176,9 +1176,7 @@ path.combo {
 </g>
 <g transform="translate(476, 154)" class="key keypos-25">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">Gui+</tspan><tspan x="0" dy="1.2em">SPACE</tspan>
-</text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;spotlight</tspan></text>
 </g>
 <g transform="translate(532, 147)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -114,6 +114,18 @@
                 <&kp LG(LSHFT)>;
         };
 
+        spotlight: spotlight {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings =
+                <&macro_press>,
+                <&kp LCMD>,
+                <&macro_tap>,
+                <&kp SPACE>,
+                <&macro_release>,
+                <&kp LCMD>;
+       }
+
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
@@ -228,10 +240,10 @@
             label = "MacFunc";
             display-name = "MacFunc";
             bindings = <
-  &kp F1      &kp F2        &kp F3  &kp F4  &kp F5     &kp F6         &kp F7        &kp F8      &kp F9        &kp F10
-  &sk LWIN    &none         &none   &none   &none      &to SYS        &none         &none       &kp F11       &kp F12
-  &kp(LG(I))  &openbrowser  &none   &none   &to Mouse  &kp LG(SPACE)  &kp LA(DOWN)  &kp LA(UP)  &kp LC(LEFT)  &kp LC(RIGHT)
-                            &trans  &trans  &trans     &trans         &trans        &trans
+  &kp F1      &kp F2        &kp F3  &kp F4  &kp F5     &kp F6      &kp F7        &kp F8      &kp F9        &kp F10
+  &sk LWIN    &none         &none   &none   &none      &to SYS     &none         &none       &kp F11       &kp F12
+  &kp(LG(I))  &openbrowser  &none   &none   &to Mouse  &spotlight  &kp LA(DOWN)  &kp LA(UP)  &kp LC(LEFT)  &kp LC(RIGHT)
+                            &trans  &trans  &trans     &trans      &trans        &trans
             >;
         };
 


### PR DESCRIPTION
- 在鍵盤 SVG 佈局中，將「Gui+ SPACE」標籤替換為較小的 spotlight 符號。
- 新增名為 spotlight 的巨集行為，包含 LCMD 與 SPACE 的按鍵序列。
- 將 spotlight 巨集綁定至鍵盤映射中的特定按鍵位置，取代先前的 LG(SPACE) 綁定。

Signed-off-by: Macbook Air <jackie@dast.tw>
