### PR TITLE
修正：修正 keymap 配置檔中的語法錯誤

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -124,7 +124,7 @@
                 <&kp SPACE>,
                 <&macro_release>,
                 <&kp LCMD>;
-       }
+       };
 
         col: tmux_column {
             compatible = "zmk,behavior-macro";


### PR DESCRIPTION
- 透過將結束大括號替換為結束大括號加分號來修正 keymap 配置中的語法錯誤。

Signed-off-by: Macbook Air <jackie@dast.tw>
