### PR TITLE
修正：將左側修飾鍵從 LWIN 改為 LALT，應用於整個配置佈局

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1117,7 +1117,7 @@ path.combo {
 </g>
 <g transform="translate(28, 105)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LWIN</text>
+<text x="0" y="0" class="key tap">LALT</text>
 <text x="0" y="24" class="key hold">sticky</text>
 </g>
 <g transform="translate(84, 91)" class="key keypos-11">

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -241,7 +241,7 @@
             display-name = "MacFunc";
             bindings = <
   &kp F1      &kp F2        &kp F3  &kp F4  &kp F5     &kp F6      &kp F7        &kp F8      &kp F9        &kp F10
-  &sk LWIN    &none         &none   &none   &none      &to SYS     &none         &none       &kp F11       &kp F12
+  &sk LALT    &none         &none   &none   &none      &to SYS     &none         &none       &kp F11       &kp F12
   &kp(LG(I))  &openbrowser  &none   &none   &to Mouse  &spotlight  &kp LA(DOWN)  &kp LA(UP)  &kp LC(LEFT)  &kp LC(RIGHT)
                             &trans  &trans  &trans     &trans      &trans        &trans
             >;


### PR DESCRIPTION
- 在 SVG 配置佈局中，將左側修飾鍵標籤由 LWIN 改為 LALT。
- 更新鍵盤映射配置中對應的按鍵綁定，將 LWIN 改為 LALT。

Signed-off-by: Macbook Air <jackie@dast.tw>
