### PR TITLE
feat：優化鍵盤映射，改進 move_up 與 move_down 鍵位綁定

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1160,7 +1160,6 @@ path.combo {
 </g>
 <g transform="translate(84, 147)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;openbrows…</tspan></text>
 </g>
 <g transform="translate(140, 140)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1180,9 +1179,11 @@ path.combo {
 </g>
 <g transform="translate(532, 147)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;move_down</tspan></text>
 </g>
 <g transform="translate(588, 140)" class="key keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 88%">&amp;move_up</tspan></text>
 </g>
 <g transform="translate(644, 147)" class="key keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -101,7 +101,7 @@
                 <&macro_release>, <&kp LG(LSHFT)>;
         };
 
-        spotlight: spotlight {
+       spotlight: spotlight {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
@@ -110,29 +110,47 @@
                 <&macro_release>, <&kp LCMD>;
        };
 
-        col: tmux_column {
+       move_up: move_up {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp PIPE>;
-        };
+            bindings =
+                <&macro_press>, <&kp LALT>,
+                <&macro_tap>, <&kp UP>,
+                <&macro_release>, <&kp LALT>;
+       }; 
 
-        row: tmux_row {
+       move_down: move_down {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp MINUS>;
-        };
+            bindings =
+                <&macro_press>, <&kp LALT>,
+                <&macro_tap>, <&kp DOWN>,
+                <&macro_release>, <&kp LALT>;
+       }; 
 
-        list: tmux_list {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp W>;
-        };
+       col: tmux_column {
+           compatible = "zmk,behavior-macro";
+           #binding-cells = <0>;
+           bindings = <&macro_tap>, <&kp LC(A)>, <&kp PIPE>;
+       };
 
-        tabs: tmux_create {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp C>;
-        };
+       row: tmux_row {
+           compatible = "zmk,behavior-macro";
+           #binding-cells = <0>;
+           bindings = <&macro_tap>, <&kp LC(A)>, <&kp MINUS>;
+       };
+
+       list: tmux_list {
+           compatible = "zmk,behavior-macro";
+           #binding-cells = <0>;
+           bindings = <&macro_tap>, <&kp LC(A)>, <&kp W>;
+       };
+
+       tabs: tmux_create {
+           compatible = "zmk,behavior-macro";
+           #binding-cells = <0>;
+           bindings = <&macro_tap>, <&kp LC(A)>, <&kp C>;
+       };
     };
 
     combos {
@@ -224,10 +242,10 @@
             label = "MacFunc";
             display-name = "MacFunc";
             bindings = <
-  &kp F1      &kp F2        &kp F3  &kp F4  &kp F5     &kp F6      &kp F7  &kp F8  &kp F9        &kp F10
-  &sk LALT    &none         &none   &none   &none      &to SYS     &none   &none   &kp F11       &kp F12
-  &kp(LG(I))  &openbrowser  &none   &none   &to Mouse  &spotlight  &none   &none   &kp LC(LEFT)  &kp LC(RIGHT)
-                            &trans  &trans  &trans     &trans      &trans  &trans
+  &kp F1      &kp F2  &kp F3  &kp F4  &kp F5     &kp F6      &kp F7      &kp F8    &kp F9        &kp F10
+  &sk LALT    &none   &none   &none   &none      &to SYS     &none       &none     &kp F11       &kp F12
+  &kp(LG(I))  &none   &none   &none   &to Mouse  &spotlight  &move_down  &move_up  &kp LC(LEFT)  &kp LC(RIGHT)
+                      &trans  &trans  &trans     &trans      &trans      &trans
             >;
         };
 


### PR DESCRIPTION
- 從 SVG 佈局中移除不必要的鍵標籤，並新增 move_up 與 move_down 鍵的標籤。
- 定義帶有 LALT 修飾鍵與方向鍵綁定的 move_up 與 move_down 新巨集行為。
- 在鍵盤映射配置中，用 move_down 與 move_up 替換 openbrowser 鍵綁定。

Signed-off-by: Macbook Air <jackie@dast.tw>
