### PR TITLE
perf: 透過移除零值清理終端機巨集配置

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -62,8 +62,6 @@
         ter_mac: terminal_macos {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
-            tap-ms = <0>;
             bindings =
                 <&macro_press>, <&kp LCMD>,
                 <&macro_tap>, <&kp SPACE>,


### PR DESCRIPTION
- 從終端機 macOS 巨集配置中移除不必要的零持續時間設定。

Signed-off-by: Macbook Air <jackie@dast.tw>
