### PR TITLE
修正：更正捲動方向標籤及按鍵綁定

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1318,13 +1318,13 @@ path.combo {
 <g transform="translate(532, 147)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">SCRL_DOWN</tspan>
+<tspan x="0" dy="-0.6em">&amp;msc</tspan><tspan x="0" dy="1.2em">SCRL_UP</tspan>
 </text>
 </g>
 <g transform="translate(588, 140)" class="key keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;msc</tspan><tspan x="0" dy="1.2em">SCRL_UP</tspan>
+<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">SCRL_DOWN</tspan>
 </text>
 </g>
 <g transform="translate(644, 147)" class="key keypos-28">

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -251,9 +251,9 @@
             label = "Mouse";
             display-name = "Mouse";
             bindings = <
-            &kp ESC  &none  &none       &none    &none         &none           &none           &none         &none            &none
-            &none    &none  &none       &none    &none         &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none
-            &none    &none  &none       &none    &none         &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none
+            &kp ESC  &none  &none       &none    &none         &none           &none           &none           &none            &none
+            &none    &none  &none       &none    &none         &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP    &mmv MOVE_RIGHT  &none
+            &none    &none  &none       &none    &none         &none           &msc SCRL_UP    &msc SCRL_DOWN  &none            &none
                             &to MacDef  &to SYS  &to WinDef    &mkp LCLK       &mkp RCLK       &mkp MCLK
             >;
         };


### PR DESCRIPTION
- 將 SVG 配置中兩個按鍵的標籤 SCRL_DOWN 與 SCRL_UP 互換，以修正顯示。
- 更新按鍵映射，對應調整捲動向上及向下的按鍵綁定。

Signed-off-by: Macbook Air <jackie@dast.tw>
