### PR TITLE
修正：修正組合鍵映射配置名稱中的拼寫錯誤

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -154,7 +154,7 @@
     combos {
         compatible = "zmk,combos";
 
-        Combo_Crtl {
+        Combo_Control {
             bindings = <&kp LCTRL>;
             key-positions = <20 21>;
             layers = <0 2>;


### PR DESCRIPTION
- 將組合鍵名稱從「Combo_Crtl」重命名為「Combo_Control」，以修正鍵盤映射配置中的拼寫錯誤

Signed-off-by: Macbook Air <jackie@dast.tw>
