### PR TITLE
重構：將 macro_tap 鍵位從方向鍵重新映射為 J 和 K 鍵

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -113,7 +113,7 @@
             #binding-cells = <0>;
             bindings =
                 <&macro_press>, <&kp LALT>,
-                <&macro_tap>, <&kp UP>,
+                <&macro_tap>, <&kp K>,
                 <&macro_release>, <&kp LALT>;
         }; 
  
@@ -122,7 +122,7 @@
             #binding-cells = <0>;
             bindings =
                 <&macro_press>, <&kp LALT>,
-                <&macro_tap>, <&kp DOWN>,
+                <&macro_tap>, <&kp J>,
                 <&macro_release>, <&kp LALT>;
         }; 
  


### PR DESCRIPTION
- 將 macro_tap 觸發的按鍵從向上和向下方向鍵分別改為 K 和 J 鍵。

Signed-off-by: Macbook Air <jackie@dast.tw>
