### PR TITLE
重構：將整個版面配置中的 GLOBE 鍵重命名為 LANG1 和 LANG2

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1129,7 +1129,7 @@ path.combo {
 </g>
 <g transform="translate(196, 91)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">GLOBE</text>
+<text x="0" y="0" class="key tap">LANG1</text>
 </g>
 <g transform="translate(252, 98)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1169,6 +1169,7 @@ path.combo {
 </g>
 <g transform="translate(196, 147)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">LANG2</text>
 </g>
 <g transform="translate(252, 154)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -263,8 +263,8 @@
             display-name = "MacFunc";
             bindings = <
             &kp F1      &kp F2  &kp F3        &kp F4     &kp F5       &kp F6      &kp F7      &kp F8    &kp F9        &kp F10
-            &sk LALT    &none   &winup_mac    &kp GLOBE  &none        &to SYS     &none       &none     &kp F11       &kp F12
-            &kp(LG(I))  &none   &windown_mac  &none      &to Mouse    &spotlight  &move_down  &move_up  &kp LC(LEFT)  &kp LC(RIGHT)
+            &sk LALT    &none   &winup_mac    &kp LANG1  &none        &to SYS     &none       &none     &kp F11       &kp F12
+            &kp(LG(I))  &none   &windown_mac  &kp LANG2  &to Mouse    &spotlight  &move_down  &move_up  &kp LC(LEFT)  &kp LC(RIGHT)
                                 &trans        &trans     &trans       &trans      &trans      &trans
             >;
         };


### PR DESCRIPTION
- 將鍵標籤從 GLOBE 重命名為 LANG1，並在 SVG 版面配置中新增 LANG2 標籤。
- 更新鍵位映射綁定，將對應按鍵從使用 GLOBE 改為 LANG1 和 LANG2。

Signed-off-by: Macbook Air <jackie@dast.tw>
