### PR TITLE
refactor: 將 LANG1/LANG2 鍵替換為 GLOBE 並簡化按鍵映射

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1129,7 +1129,7 @@ path.combo {
 </g>
 <g transform="translate(196, 91)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LANG1</text>
+<text x="0" y="0" class="key tap">GLOBE</text>
 </g>
 <g transform="translate(252, 98)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1169,7 +1169,6 @@ path.combo {
 </g>
 <g transform="translate(196, 147)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LANG2</text>
 </g>
 <g transform="translate(252, 154)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -102,8 +102,6 @@
         winup_mac: windowup_mac {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
-            tap-ms = <0>;
             bindings =
                 <&macro_press>, <&kp GLOBE>, <&kp LCTRL>,
                 <&macro_tap>, <&kp F>,
@@ -113,8 +111,6 @@
         windown_mac: windowdown_mac {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
-            tap-ms = <0>;
             bindings =
                 <&macro_press>, <&kp GLOBE>, <&kp LCTRL>,
                 <&macro_tap>, <&kp C>,
@@ -263,8 +259,8 @@
             display-name = "MacFunc";
             bindings = <
             &kp F1      &kp F2  &kp F3        &kp F4     &kp F5       &kp F6      &kp F7      &kp F8    &kp F9        &kp F10
-            &sk LALT    &none   &winup_mac    &kp LANG1  &none        &to SYS     &none       &none     &kp F11       &kp F12
-            &kp(LG(I))  &none   &windown_mac  &kp LANG2  &to Mouse    &spotlight  &move_down  &move_up  &kp LC(LEFT)  &kp LC(RIGHT)
+            &sk LALT    &none   &winup_mac    &kp GLOBE  &none        &to SYS     &none       &none     &kp F11       &kp F12
+            &kp(LG(I))  &none   &windown_mac  &none      &to Mouse    &spotlight  &move_down  &move_up  &kp LC(LEFT)  &kp LC(RIGHT)
                                 &trans        &trans     &trans       &trans      &trans      &trans
             >;
         };


### PR DESCRIPTION
- 將 SVG 圖像中的「LANG1」按鍵標籤替換為「GLOBE」，並移除「LANG2」按鍵標籤。
- 從按鍵映射中的兩個巨集行為中刪除明確的等待與點擊時間參數。
- 更新按鍵映射綁定，將「LANG1」按鍵碼替換為「GLOBE」，並移除佈局中的「LANG2」按鍵碼綁定。

Signed-off-by: Macbook Air <jackie@dast.tw>
