### PR TITLE
重構：優化系統切換的鍵盤映射及鍵位標籤分配

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -977,13 +977,9 @@ path.combo {
 </g>
 <g transform="translate(252, 98)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">Alt+C</text>
 </g>
 <g transform="translate(476, 98)" class="key keypos-15">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(532, 91)" class="key keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1023,6 +1019,9 @@ path.combo {
 </g>
 <g transform="translate(476, 154)" class="key keypos-25">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(532, 147)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1136,9 +1135,7 @@ path.combo {
 </g>
 <g transform="translate(476, 98)" class="key keypos-15">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;spotlight</tspan></text>
 </g>
 <g transform="translate(532, 91)" class="key keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1178,7 +1175,9 @@ path.combo {
 </g>
 <g transform="translate(476, 154)" class="key keypos-25">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;spotlight</tspan></text>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(532, 147)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -248,8 +248,8 @@
             display-name = "WinFunc";
             bindings = <
             &kp F1      &kp F2        &kp F3  &kp F4  &kp F5       &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
-            &sk LWIN    &none         &none   &none   &kp LA(C)    &to SYS  &none          &none           &kp F11           &kp F12
-            &kp(LG(I))  &openbrowser  &none   &none   &to Mouse    &none    &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+            &sk LWIN    &none         &none   &none   &none        &none    &none          &none           &kp F11           &kp F12
+            &kp(LG(I))  &openbrowser  &none   &none   &to Mouse    &to SYS  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
                                       &trans  &trans  &trans       &trans   &trans         &trans
             >;
         };
@@ -259,8 +259,8 @@
             display-name = "MacFunc";
             bindings = <
             &kp F1      &kp F2  &kp F3        &kp F4     &kp F5       &kp F6      &kp F7      &kp F8    &kp F9        &kp F10
-            &sk LALT    &none   &winup_mac    &kp GLOBE  &none        &to SYS     &none       &none     &kp F11       &kp F12
-            &kp(LG(I))  &none   &windown_mac  &none      &to Mouse    &spotlight  &move_down  &move_up  &kp LC(LEFT)  &kp LC(RIGHT)
+            &sk LALT    &none   &winup_mac    &kp GLOBE  &none        &spotlight  &none       &none     &kp F11       &kp F12
+            &kp(LG(I))  &none   &windown_mac  &none      &to Mouse    &to SYS     &move_down  &move_up  &kp LC(LEFT)  &kp LC(RIGHT)
                                 &trans        &trans     &trans       &trans      &trans      &trans
             >;
         };


### PR DESCRIPTION
- 移除 SVG 中多餘的鍵位標籤與連結，將系統層啟動鍵文字移至其他鍵位位置
- 更新鍵盤映射綁定，將部分系統層啟動鍵與聚光燈鍵替換為直接系統切換功能
- 調整 MacFunc 層綁定，交換聚光燈與系統切換鍵的位置
- 清理鍵盤映射，刪除部分不必要或重複的鍵位分配

Signed-off-by: Macbook Air <jackie@dast.tw>
