### PR TITLE
重構：重構巨集與快捷鍵以提升視窗管理

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1003,7 +1003,7 @@ path.combo {
 </g>
 <g transform="translate(84, 147)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;openbrows…</tspan></text>
+<text x="0" y="0" class="key tap">&amp;edge</text>
 </g>
 <g transform="translate(140, 140)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -31,7 +31,7 @@
 /*    chosen { zmk,physical-layout = &foostan_corne_5col_layout; }; */
 
     macros {
-        openbrowser: start_edge {
+        edge: start_edge {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             wait-ms = <0>;
@@ -51,10 +51,14 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
+
+                // 開啟執行視窗
                 <&macro_press>, <&kp LWIN>,
                 <&macro_tap>, <&kp R>,
                 <&macro_release>, <&kp LWIN>,
                 <&macro_pause_for_release>,
+
+                // 輸入WT 後按下ENTER執行
                 <&macro_tap>,
                 <&kp W>, <&kp T>, <&kp RET>;
         };
@@ -62,16 +66,28 @@
         ter_mac: terminal_macos {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
+        
+                // 開啟 Spotlight
                 <&macro_press>, <&kp LCMD>,
                 <&macro_tap>, <&kp SPACE>,
                 <&macro_release>, <&kp LCMD>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
+
+                // 等待 Spotlight 完全開啟
+                <&macro_wait_time 300>,
+
+                // 輸入 ghostty.app
                 <&macro_tap>,
                 <&kp G>, <&kp H>, <&kp O>, <&kp S>, <&kp T>, <&kp T>, <&kp Y>,
                 <&kp DOT>, <&kp A>, <&kp P>, <&kp P>,
-                <&macro_wait_time 120>,
+
+                // 等待 Spotlight 搜尋結果穩定
+                <&macro_wait_time 400>,
+
+                // 按下 Enter 啟動
                 <&macro_tap>, <&kp RET>;
         };
 
@@ -81,11 +97,15 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LCMD &kp LCTRL>,
+
+                // 按住 CMD+Control 
+                <&macro_press>, <&kp LG(LCTRL)>,
+
+                // 按下 F 視窗放大 
                 <&macro_tap>, <&kp F>,
-                <&macro_release>,
-                <&kp LCMD>, <&kp LCTRL>;
+
+                // 釋放 CMD+Control
+                <&macro_release>, <&kp LG(LCTRL)>;
         };
  
         rec_mac: screenrecord_mac {
@@ -94,8 +114,14 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
+
+                // 按住 CMD+Shift
                 <&macro_press>, <&kp LG(LSHFT)>,
+
+                // 按下 數字5 啟動錄影
                 <&macro_tap>, <&kp N5>,
+
+                // 釋放 CMD+Shift
                 <&macro_release>, <&kp LG(LSHFT)>;
         };
  
@@ -103,8 +129,14 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
+
+                // 按住 Globe+Control
                 <&macro_press>, <&kp GLOBE>, <&kp LCTRL>,
+
+                // 按下  放大視窗
                 <&macro_tap>, <&kp F>,
+
+                // 釋放 Globe+Control
                 <&macro_release>, <&kp GLOBE>, <&kp LCTRL>;
         };
 
@@ -112,8 +144,14 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
+
+                // 按住 Globe+Control
                 <&macro_press>, <&kp GLOBE>, <&kp LCTRL>,
+
+                // 按下 C 取消放大視窗
                 <&macro_tap>, <&kp C>,
+
+                // 釋放 Globe+Control
                 <&macro_release>, <&kp GLOBE>, <&kp LCTRL>;
         };
 
@@ -121,6 +159,8 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
+
+                // 開啟 Spotlight
                 <&macro_press>, <&kp LCMD>,
                 <&macro_tap>, <&kp SPACE>,
                 <&macro_release>, <&kp LCMD>;
@@ -130,6 +170,8 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
+
+                // 移動整行向上
                 <&macro_press>, <&kp LALT>,
                 <&macro_tap>, <&kp K>,
                 <&macro_release>, <&kp LALT>;
@@ -139,6 +181,8 @@
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
+
+                // 移動整行向下
                 <&macro_press>, <&kp LALT>,
                 <&macro_tap>, <&kp J>,
                 <&macro_release>, <&kp LALT>;
@@ -247,10 +291,10 @@
             label = "WinFunc";
             display-name = "WinFunc";
             bindings = <
-            &kp F1      &kp F2        &kp F3  &kp F4  &kp F5       &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
-            &sk LWIN    &none         &none   &none   &none        &none    &none          &none           &kp F11           &kp F12
-            &kp(LG(I))  &openbrowser  &none   &none   &to Mouse    &to SYS  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
-                                      &trans  &trans  &trans       &trans   &trans         &trans
+            &kp F1      &kp F2  &kp F3  &kp F4  &kp F5       &kp F6   &kp F7         &kp F8          &kp F9            &kp F10
+            &sk LWIN    &none   &none   &none   &none        &none    &none          &none           &kp F11           &kp F12
+            &kp(LG(I))  &edge   &none   &none   &to Mouse    &to SYS  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))
+                                &trans  &trans  &trans       &trans   &trans         &trans
             >;
         };
     


### PR DESCRIPTION
- 將 SVG 中的按鍵標籤由符號字串更新為「edge」
- 在鍵盤映射配置中將巨集名稱由「openbrowser」重新命名為「edge」
- 新增多個 macOS 專用巨集，包括透過 Spotlight 啟動終端機、最大化視窗、開始螢幕錄製、視窗上下移動及開啟 Spotlight
- 使用中文註解描述每個巨集的功能以增進可讀性
- 調整終端機啟動巨集中的時間設定以提升穩定度
- 在佈局配置中將快捷鍵綁定由「openbrowser」更換為新的「edge」巨集

Signed-off-by: Macbook Air <jackie@dast.tw>
