### PR TITLE
perf: 消除 Spotlight 搜尋輸入前不必要的等待時間

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -80,9 +80,6 @@
                 <&macro_release>, <&kp LCMD>,
                 <&macro_pause_for_release>,
 
-                // 等待 Spotlight 完全開啟
-                <&macro_wait_time 300>,
-
                 // 輸入 ghostty.app
                 <&macro_tap>,
                 <&kp G>, <&kp H>, <&kp O>, <&kp S>, <&kp T>, <&kp T>, <&kp Y>,


### PR DESCRIPTION
- 移除先前為確保 Spotlight 完全開啟而設置的 300 毫秒等待時間，輸入「ghostty.app」

Signed-off-by: Macbook Air <jackie@dast.tw>
