### PR TITLE
test: 新增延遲巨集以確保 Spotlight 在輸入前已準備就緒

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -80,6 +80,9 @@
                 <&macro_release>, <&kp LCMD>,
                 <&macro_pause_for_release>,
 
+                // 等待 Spotlight 完全開啟
+                <&macro_wait_time 300>,
+
                 // 輸入 ghostty.app
                 <&macro_tap>,
                 <&kp G>, <&kp H>, <&kp O>, <&kp S>, <&kp T>, <&kp T>, <&kp Y>,


### PR DESCRIPTION
- 新增 300 毫秒等待巨集，確保 Spotlight 完全開啟後再輸入文字

Signed-off-by: Macbook Air <jackie@dast.tw>
