### PR TITLE
perf：減少 Spotlight 啟動延遲以提升響應速度

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -81,7 +81,7 @@
                 <&macro_pause_for_release>,
 
                 // 等待 Spotlight 完全開啟
-                <&macro_wait_time 300>,
+                <&macro_wait_time 150>,
 
                 // 輸入 ghostty.app
                 <&macro_tap>,


### PR DESCRIPTION
- 將 Spotlight 完全開啟的等待時間從 300 毫秒減少至 150 毫秒

Signed-off-by: Macbook Air <jackie@dast.tw>
