### PR TITLE
perf: 透過降低巨集等待時間提升 Spotlight 搜尋速度

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -89,7 +89,7 @@
                 <&kp DOT>, <&kp A>, <&kp P>, <&kp P>,
 
                 // 等待 Spotlight 搜尋結果穩定
-                <&macro_wait_time 400>,
+                <&macro_wait_time 300>,
 
                 // 按下 Enter 啟動
                 <&macro_tap>, <&kp RET>;


### PR DESCRIPTION
- 將巨集等待時間從 400 毫秒縮短至 300 毫秒，以加快 Spotlight 搜尋的啟動速度。

Signed-off-by: Macbook Air <jackie@dast.tw>
