### PR TITLE
refactor: 從配置中移除多餘的巨集暫停指令

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -78,7 +78,6 @@
                 <&macro_press>, <&kp LCMD>,
                 <&macro_tap>, <&kp SPACE>,
                 <&macro_release>, <&kp LCMD>,
-                <&macro_pause_for_release>,
 
                 // 等待 Spotlight 完全開啟
                 <&macro_wait_time 150>,


### PR DESCRIPTION
- 從配置中移除不必要的巨集暫停指令。

Signed-off-by: Macbook Air <jackie@dast.tw>
