### PR TITLE
修正：增加宏延遲以提升鍵盤映射響應速度

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -89,7 +89,7 @@
                 <&kp DOT>, <&kp A>, <&kp P>, <&kp P>,
 
                 // 等待 Spotlight 搜尋結果穩定
-                <&macro_wait_time 200>,
+                <&macro_wait_time 300>,
 
                 // 按下 Enter 啟動
                 <&macro_tap>, <&kp RET>;


### PR DESCRIPTION
- 將 corne 鍵盤映射配置中的宏等待時間從 200 毫秒增加到 300 毫秒。

Signed-off-by: Macbook Air <jackie@dast.tw>
