### PR TITLE
perf: 增加 Spotlight 等待時間以提升巨集穩定性

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -81,7 +81,7 @@
                 <&macro_pause_for_release>,
 
                 // 等待 Spotlight 完全開啟
-                <&macro_wait_time 80>,
+                <&macro_wait_time 150>,
 
                 // 輸入 ghostty.app
                 <&macro_tap>,


### PR DESCRIPTION
- 將 Spotlight 完全開啟的等待時間從 80 單位增加至 150 單位於巨集流程中。

Signed-off-by: Macbook Air <jackie@dast.tw>
