### PR TITLE
重構：改進視窗處理並提升綁定可讀性

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -62,6 +62,9 @@
                 <&macro_release>, <&kp LWIN>,
                 <&macro_pause_for_release>,
 
+                // 等待 執行視窗 完全開啟
+                <&macro_wait_time 150>,
+
                 // 輸入WT 後按下ENTER執行
                 <&macro_tap>,
                 <&kp W>, <&kp T>, <&kp RET>;
@@ -179,25 +182,29 @@
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp PIPE>;
+            bindings = 
+                <&macro_tap>, <&kp LC(A)>, <&kp PIPE>;
         };
  
         row: tmux_row {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp MINUS>;
+            bindings = 
+                <&macro_tap>, <&kp LC(A)>, <&kp MINUS>;
         };
  
         list: tmux_list {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp W>;
+            bindings = 
+                <&macro_tap>, <&kp LC(A)>, <&kp W>;
         };
  
         tabs: tmux_create {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp C>;
+            bindings = 
+                <&macro_tap>, <&kp LC(A)>, <&kp C>;
         };
     };
  


### PR DESCRIPTION
- 新增等待巨集，暫停150毫秒以確保視窗完全開啟後繼續執行
- 重新格式化綁定定義，將每個綁定置於獨立一行以提升可讀性

Signed-off-by: Macbook Air <jackie@dast.tw>
