### PR TITLE
修正：新增等待巨集以確保視窗完全開啟後再進行輸入

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -44,6 +44,9 @@
                 <&macro_release>, <&kp LWIN>,
                 <&macro_pause_for_release>,
 
+                // 等待 執行視窗 完全開啟
+                <&macro_wait_time 150>,
+                
                 // 輸入msedge 後按下Enter執行啟動瀏覽器
                 <&macro_tap>,
                 <&kp M>, <&kp S>, <&kp E>, <&kp D>, <&kp G>, <&kp E>, <&kp RET>;


### PR DESCRIPTION
- 新增 150 毫秒等待時間的巨集，確保視窗完全開啟後再繼續進行後續輸入。

Signed-off-by: Macbook Air <jackie@dast.tw>
