### PR TITLE
重構：修正 Corne 鍵盤配置中的標籤顯示並重新排列重置鍵順序

### DIFF
--- a/IMG/corne.svg
+++ b/IMG/corne.svg
@@ -1433,11 +1433,11 @@ path.combo {
 </g>
 <g transform="translate(252, 98)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;bootloader</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;sys_reset</tspan></text>
 </g>
 <g transform="translate(476, 98)" class="key keypos-15">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;bootloader</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;sys_reset</tspan></text>
 </g>
 <g transform="translate(532, 91)" class="key keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1465,11 +1465,11 @@ path.combo {
 </g>
 <g transform="translate(252, 154)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;sys_reset</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;bootloader</tspan></text>
 </g>
 <g transform="translate(476, 154)" class="key keypos-25">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;sys_reset</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;bootloader</tspan></text>
 </g>
 <g transform="translate(532, 147)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -323,8 +323,8 @@
             display-name = "System";
             bindings = <
             &none  &none  &none  &none  &bt BT_CLR     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-            &none  &none  &none  &none  &bootloader    &bootloader   &none         &none         &none         &none
             &none  &none  &none  &none  &sys_reset     &sys_reset    &none         &none         &none         &none
+            &none  &none  &none  &none  &bootloader    &bootloader   &none         &none         &none         &none
                           &none  &none  &none          &to MacDef    &to Mouse     &to WinDef
             >;
         };


### PR DESCRIPTION
- 交換 corne.svg 中 bootloader 與 sys_reset 的標籤，以修正其顯示及大小。
- 調整 corne.keymap 中的按鍵綁定，讓 sys_reset 鍵出現在 bootloader 鍵之前，以提升清晰度與一致性。

Signed-off-by: WSL <jackie@dast.tw>
