### PR TITLE
chore：改進拉取請求事件處理與合併控制

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,32 +1,27 @@
----
 name: automerge
+
 on:
   pull_request:
     types:
       - labeled
-      - unlabeled
       - synchronize
       - opened
-      - edited
-      - ready_for_review
       - reopened
-      - unlocked
+      - ready_for_review
   pull_request_review:
-    types:
-      - submitted
+    types: [submitted]
   check_suite:
-    types:
-      - completed
+    types: [completed]
   status: {}
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - id: automerge
-        name: automerge
+      - name: automerge
         uses: pascalgn/automerge-action@v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          MERGE_LABELS: ''
-          MERGE_FILTER_AUTHOR: cloverdefa
-          MERGE_DELETE_BRANCH_FILTER: test
+          MERGE_LABELS: ""               # 不需要 label
+          MERGE_METHOD: "squash"         # merge squash rebase
+          MERGE_FILTER_AUTHOR: "cloverdefa"  # 只自動合併自己開的 PR


### PR DESCRIPTION
- 更新觸發條件，將 ready_for_review 包含在拉取請求事件中
- 添加入提交作為唯一允許的拉取請求審查事件類型
- 限制檢查套件事件僅在完成時觸發
- 為清晰起見將步驟名稱改為 automerge
- 刪除未使用的環境變數並添加標籤排除註解
- 設定合併方式為 squash，並限制自動合併僅適用於特定用戶發起的 PR

Signed-off-by: WSL <39210648+cloverdefa@users.noreply.github.com>
