### PR TITLE
refactor(keymap): 重構並簡化鍵位設定，以提升一致性

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -42,15 +42,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LG(LALT)>,
+                <&kp LC(LALT)>,
                 <&macro_tap>,
-                <&kp SPACE>,
+                <&kp E>,
                 <&macro_release>,
-                <&kp LG(LALT)>,
-                <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
-                <&macro_tap>,
-                <&kp E &kp D &kp G &kp E &kp RET>;
+                <&kp LC(LALT)>;
         };
 
         ter_win: terminal_windows {


### PR DESCRIPTION
- 將原本包含 LG(LALT) 的綁定替換為 LC(LALT)
- 移除了涉及空白鍵、E 及其他鍵的按鍵序列
- 在鍵位列表的最後新增了 LC(LALT) 的綁定
- 簡化了與終端視窗相關的鍵序列