### PR TITLE
chore(build)：重構建設與配置文件以提高清晰度與一致性

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,12 +1,12 @@
 ---
 include:
   - board: nice_nano_v2
-    shield: corne_left nice_view_adapter nice_view_gem
+    shield: corne_left nice_view_adapter nice_view
     artifact-name: corne-left
     # snippet: studio-rpc-usb-uart
 
   - board: nice_nano_v2
-    shield: corne_right nice_view_adapter nice_view_gem
+    shield: corne_right nice_view_adapter nice_view
     artifact-name: corne-right
     # snippet: studio-rpc-usb-uart
 

--- a/config/corne.conf
+++ b/config/corne.conf
@@ -42,14 +42,6 @@ CONFIG_ZMK_KEYBOARD_NAME="Corne-5"
 
 CONFIG_ZMK_POINTING=y
 
-
-# =========================
-# 🖥️ nice!view GEM
-# =========================
-
-CONFIG_ZMK_DISPLAY=y
-CONFIG_ZMK_DISPLAY_STATUS_SCREEN_CUSTOM=y
-
 # =========================
 # 🧪 開發功能
 # =========================

--- a/config/west.yml
+++ b/config/west.yml
@@ -4,18 +4,11 @@ manifest:
     - name: zmkfirmware
       url-base: https://github.com/zmkfirmware
 
-    - name: m165437
-      url-base: https://github.com/M165437
-
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: v0.3.0
+      revision: v0.3
       import: app/west.yml
-
-    - name: nice-view-gem
-      remote: m165437
-      revision: main
 
   self:
     path: config


### PR DESCRIPTION
chore(build)：重構建設與配置文件以提高清晰度與一致性
- 將 build.yaml 中的 shield 名稱更新為更簡短的形式
- 從 corne.conf 中移除未使用的顯示配置行
- 對 west.yml 中的版本參考進行微調以保持一致性
- 在 west.yml 中註解掉專案條目以停用某些依賴項

Signed-off-by: DAST <39210648+cloverdefa@users.noreply.github.com>

---
Merge branch 'dev'

---
chore(build): 標準化配置命名並啟用自定義顯示設定 (#239)

---